### PR TITLE
Using NDIlib_find_get_current_sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+Processing.NDI.Lib.x64.dll

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,7 +677,11 @@ pub enum AudioType {
 
 impl From<u32> for AudioType {
     fn from(value: u32) -> Self {
-        if value == NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP {
+        if value
+            == NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP
+                .try_into()
+                .unwrap()
+        {
             AudioType::FLTP
         } else {
             AudioType::Max
@@ -688,8 +692,31 @@ impl From<u32> for AudioType {
 impl From<AudioType> for u32 {
     fn from(audio_type: AudioType) -> Self {
         match audio_type {
-            AudioType::FLTP => NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
-            AudioType::Max => NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_max,
+            AudioType::FLTP => NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP
+                .try_into()
+                .unwrap(),
+            AudioType::Max => NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_max
+                .try_into()
+                .unwrap(),
+        }
+    }
+}
+
+impl From<i32> for AudioType {
+    fn from(value: i32) -> Self {
+        if value == NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP as i32 {
+            AudioType::FLTP
+        } else {
+            AudioType::Max
+        }
+    }
+}
+
+impl From<AudioType> for i32 {
+    fn from(audio_type: AudioType) -> Self {
+        match audio_type {
+            AudioType::FLTP => NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP as i32,
+            AudioType::Max => NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_max as i32,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,24 @@ impl<'a> Find<'a> {
         unsafe { NDIlib_find_wait_for_sources(self.instance, timeout) }
     }
 
+    pub fn get_current_sources(&self) -> Result<Vec<Source>, Error> {
+        let mut no_sources = 0;
+        let sources_ptr =
+            unsafe { NDIlib_find_get_current_sources(self.instance, &mut no_sources) };
+        if sources_ptr.is_null() {
+            return Ok(vec![]);
+        }
+        let sources = unsafe {
+            (0..no_sources)
+                .map(|i| {
+                    let source = &*sources_ptr.add(i as usize);
+                    Source::from_raw(source)
+                })
+                .collect()
+        };
+        Ok(sources)
+    }
+
     pub fn get_sources(&self, timeout: u32) -> Result<Vec<Source>, Error> {
         let mut no_sources = 0;
         let sources_ptr =


### PR DESCRIPTION
The newer version of the NDISDK uses `NDIlib_find_get_current_sources`.  I have NDI SDK 6.1.1.0 installed.

See here:
https://docs.ndi.video/all/developing-with-ndi/sdk/ndi-find

I couldn't find any mention of the change in NDI SDK docs or the old call even mentioned in there anymore

I added a new function instead of updating the old function, just in case I was missing something here.

`ndi_find.get_current_sources()`

Obviously you don't have to use my fork, but I wasn't getting what I expected with the old call `get_sources`.

NOTE:
Pretty new to Rust, but had a few compile errors. That I "fixed", appreciate if anyone more versed can take a look at how I handled  the i32>u32 traits.





