### PR TITLE
feat: add get_current_sources method to Finder

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -213,6 +213,49 @@ impl<'a> Finder<'a> {
         unsafe { NDIlib_find_wait_for_sources(self.instance, timeout) }
     }
 
+    /// Gets the current list of discovered sources (snapshot).
+    ///
+    /// This method uses `NDIlib_find_get_current_sources` which provides a snapshot
+    /// of the current source list without any additional network discovery.
+    ///
+    /// # Returns
+    ///
+    /// A vector of currently known sources. May be empty if no sources are found.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use grafton_ndi::{NDI, FinderOptions, Finder};
+    /// # fn main() -> Result<(), grafton_ndi::Error> {
+    /// # let ndi = NDI::new()?;
+    /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
+    /// // Get current snapshot of sources
+    /// let sources = finder.get_current_sources()?;
+    ///
+    /// for source in sources {
+    ///     println!("Current source: {}", source);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_current_sources(&self) -> Result<Vec<Source>, Error> {
+        let mut num_sources = 0;
+        let sources_ptr =
+            unsafe { NDIlib_find_get_current_sources(self.instance, &mut num_sources) };
+        if sources_ptr.is_null() {
+            return Ok(vec![]);
+        }
+        let sources = unsafe {
+            (0..num_sources)
+                .map(|i| {
+                    let source = &*sources_ptr.add(i as usize);
+                    Source::from_raw(source)
+                })
+                .collect()
+        };
+        Ok(sources)
+    }
+
     /// Gets the current list of discovered sources.
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary
- Adds `Finder::get_current_sources()` method for NDI SDK 6.1.1+ compatibility
- Based on work from PR #3 by @kaine-bruce-dmt, cleaned up and integrated

## Changes
- Added `get_current_sources()` method that uses `NDIlib_find_get_current_sources`
- Provides a snapshot of current sources without additional network discovery
- Properly documented with examples

## Testing
- [x] Code compiles successfully
- [x] All unit tests pass
- [ ] Needs testing with NDI SDK 6.1.1+ to verify functionality

## Notes
This supersedes PR #3 which had merge conflicts. The type conversion issues mentioned in the original PR are not needed as the current codebase uses `num_enum` derive macros that handle the conversions automatically.

The NDI SDK documentation indicates that `NDIlib_find_get_current_sources` is the recommended method in newer SDK versions for getting an immediate snapshot of sources.

Closes #3