### PR TITLE
fix: Audio frame sending now works correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Audio frame sending now works correctly** ([#10](https://github.com/GrantSparks/grafton-ndi/issues/10))
+  - `AudioFrameBuilder` now properly calculates `channel_stride_in_bytes` based on audio layout
+  - Default layout changed to **Planar** (matching FLTP format semantics)
+  - Previously hardcoded to 0 (interleaved), causing NDI SDK to reject audio samples entirely
+  - `NDIlib_Send_Audio` example now functional
+
+### Added
+- **`AudioLayout` enum**: Explicit control over audio data layout
+  - `AudioLayout::Planar` - All samples for channel 0, then channel 1, etc. (new default)
+  - `AudioLayout::Interleaved` - Samples from all channels interleaved
+- **`AudioFrameBuilder::layout()`**: Method to specify planar or interleaved audio format
+- Comprehensive documentation with memory layout diagrams for both formats
+- Test coverage for both planar and interleaved audio formats (4 new tests)
+
+### Changed
+- **BREAKING**: `AudioFrameBuilder` now defaults to planar layout
+  - `channel_stride_in_bytes` now correctly set to `num_samples * 4` (was 0)
+  - Users requiring interleaved format must explicitly call `.layout(AudioLayout::Interleaved)`
+  - This fixes completely broken audio sending functionality
+  - Planar is the correct default as FLTP means "Float Planar"
+
 ## [0.9.0] - 2025-10-19
 
 ### Major Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub use {
     error::*,
     finder::{Finder, FinderOptions, FinderOptionsBuilder, Source, SourceAddress, SourceCache},
     frames::{
-        AudioFrame, AudioFrameBuilder, AudioType, FourCCVideoType, FrameFormatType,
+        AudioFrame, AudioFrameBuilder, AudioLayout, AudioType, FourCCVideoType, FrameFormatType,
         LineStrideOrSize, MetadataFrame, VideoFrame, VideoFrameBuilder,
     },
     receiver::{


### PR DESCRIPTION
## Summary

Fixes #10 - Audio frames can now be sent successfully through NDI

The `AudioFrameBuilder` was creating frames with incompatible format settings that caused the NDI SDK to reject all audio samples. This PR implements complete support for both planar and interleaved audio layouts.

## Root Cause

The builder had conflicting format settings:
- Default `AudioType::FLTP` (Float Planar format)
- But `channel_stride_in_bytes: 0` (which indicates interleaved format)

This mismatch caused the NDI SDK to reject audio frames entirely.

## Changes

### Added
- **`AudioLayout` enum**: Explicit control over audio data layout
  - `AudioLayout::Planar` - All samples for channel 0, then channel 1, etc. (new default)
  - `AudioLayout::Interleaved` - Samples from all channels interleaved
- **`AudioFrameBuilder::layout()`**: Method to specify planar or interleaved format
- Comprehensive documentation with memory layout diagrams
- 4 new tests covering both planar and interleaved formats

### Fixed
- `AudioFrameBuilder::build()` now correctly calculates `channel_stride_in_bytes`:
  - **Planar** (default): `num_samples * 4` bytes (4 bytes per f32)
  - **Interleaved**: `0`
- `NDIlib_Send_Audio` example now functional

### Breaking Changes

⚠️ **BREAKING**: `AudioFrameBuilder` now defaults to planar layout
- `channel_stride_in_bytes` changes from `0` to `num_samples * 4`
- Users requiring interleaved format must explicitly call `.layout(AudioLayout::Interleaved)`
- This is the correct default since FLTP means "Float Planar"
- Fixes completely broken audio sending functionality

## Testing

All tests pass (43/43):
- ✅ `test_audio_frame_channel_data_interleaved` - Tests interleaved format
- ✅ `test_audio_frame_channel_data_planar` - Tests planar format
- ✅ `test_audio_frame_default_layout` - Tests default behavior
- ✅ `test_audio_frame_builder` - Updated for new default
- ✅ `cargo fmt --check` - No formatting issues
- ✅ `cargo clippy --all-targets --all-features` - Zero warnings
- ✅ `cargo build --example NDIlib_Send_Audio` - Example compiles successfully

## Files Modified

- `src/frames.rs` - Added `AudioLayout` enum, updated `AudioFrameBuilder` (+70 lines)
- `src/lib.rs` - Exported `AudioLayout`
- `src/tests.rs` - Added comprehensive tests (+53 lines)
- `CHANGELOG.md` - Documented breaking change (+22 lines)

## Usage Examples

### Planar Format (Default - Recommended)
```rust
let frame = AudioFrame::builder()
    .sample_rate(48000)
    .channels(2)
    .samples(1920)
    .data(planar_data)  // [C0S0, C0S1, ..., C1S0, C1S1, ...]
    .build()?;
// channel_stride_in_bytes = 1920 * 4 = 7680
```

### Interleaved Format (Explicit)
```rust
let frame = AudioFrame::builder()
    .sample_rate(48000)
    .channels(2)
    .samples(1920)
    .layout(AudioLayout::Interleaved)
    .data(interleaved_data)  // [C0S0, C1S0, C0S1, C1S1, ...]
    .build()?;
// channel_stride_in_bytes = 0
```