### PR TITLE
feat: Add zero-copy borrowed receive frames (Issue #23)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,9 @@ pub use {
     error::*,
     finder::{Finder, FinderOptions, FinderOptionsBuilder, Source, SourceAddress, SourceCache},
     frames::{
-        AudioFrame, AudioFrameBuilder, AudioLayout, AudioType, FourCCVideoType, FrameFormatType,
-        LineStrideOrSize, MetadataFrame, VideoFrame, VideoFrameBuilder,
+        AudioFrame, AudioFrameBuilder, AudioFrameRef, AudioLayout, AudioType, FourCCVideoType,
+        FrameFormatType, LineStrideOrSize, MetadataFrame, MetadataFrameRef, VideoFrame,
+        VideoFrameBuilder, VideoFrameRef,
     },
     receiver::{
         ConnectionStats, FrameType, Receiver, ReceiverBandwidth, ReceiverColorFormat,


### PR DESCRIPTION
## Summary

This PR implements zero-copy borrowed receive frames (`VideoFrameRef`, `AudioFrameRef`, `MetadataFrameRef`) that eliminate per-frame copies on the receive path, addressing Issue #23.

## Key Changes

### New Borrowed Frame Types (src/frames.rs)

Added three new public types that wrap RAII guards and expose zero-copy views:

- **`VideoFrameRef`** - Zero-copy borrowed video frame
  - Wraps `RecvVideoGuard` internally
  - `data()` returns `&[u8]` directly from NDI SDK buffer (no memcpy)
  - Provides accessor methods for all frame properties (width, height, fourcc, timecode, etc.)
  - `to_owned()` converts to owned `VideoFrame` when needed
  - ~410 lines with comprehensive rustdoc

- **`AudioFrameRef`** - Zero-copy borrowed audio frame
  - Wraps `RecvAudioGuard` internally  
  - `data()` returns `&[f32]` directly from NDI SDK buffer
  - Similar accessor pattern to `VideoFrameRef`
  - ~110 lines with documentation

- **`MetadataFrameRef`** - Zero-copy borrowed metadata frame
  - Wraps `RecvMetadataGuard` internally
  - `data()` returns `&CStr` directly from NDI SDK buffer
  - ~60 lines with documentation

All three types:
- Are **not `Send`** (inherit from guards) - prevents cross-thread use of FFI buffers
- Implement RAII - exactly one `NDIlib_recv_free_*` per frame via `Drop`
- Have comprehensive rustdoc with examples and performance notes

### New Receiver Methods (src/receiver.rs)

Added three new zero-copy capture methods:

- **`capture_video_ref(&self, timeout_ms) -> Result<Option<VideoFrameRef>>`**
  - Zero allocations, zero copies on hot path
  - Full documentation with performance metrics
  - Example: saves ~8.3 MB memcpy per 1080p BGRA frame (~475 MB/s @ 60fps)

- **`capture_audio_ref(&self, timeout_ms) -> Result<Option<AudioFrameRef>>`**
  - Similar zero-copy pattern for audio

- **`capture_metadata_ref(&self, timeout_ms) -> Result<Option<MetadataFrameRef>>`**
  - Zero-copy metadata capture

### Refactored Existing `capture_*` Methods

Per the issue requirement to "delegate to borrowed path," all existing owned capture methods now:

```rust
pub fn capture_video(&self, timeout_ms: u32) -> Result<Option<VideoFrame>> {
    match self.capture_video_ref(timeout_ms)? {
        Some(frame_ref) => Ok(Some(frame_ref.to_owned()?)),
        None => Ok(None),
    }
}
```

This ensures:
- Single source of truth for frame capture logic
- All size calculations and invariant checks happen in one place
- Behavior is identical to previous implementation
- Existing tests continue to pass

### Public API Exports (src/lib.rs)

Exported all three new types:
```rust
pub use frames::{
    AudioFrameRef, MetadataFrameRef, VideoFrameRef, ...
};
```

## Performance Impact

- **Eliminates ~8.3 MB memcpy** per 1080p BGRA frame (1920×1080×4 bytes)
- **Saves ~475 MB/s memory bandwidth** at 60fps
- Zero allocations on the borrowed path until `to_owned()` is called

## Type Safety Guarantees

- `VideoFrameRef`/`AudioFrameRef`/`MetadataFrameRef` are **`!Send`** - prevents accidental cross-thread use of FFI buffers
- Slices returned by `data()` are lifetime-tied to `&self` - prevents use-after-free at compile time
- Exactly one `NDIlib_recv_free_*` per borrowed frame via RAII `Drop` - no double frees

## Testing

✅ **All 57 existing tests pass** (`cargo test --lib --all-features`)
✅ **Zero clippy warnings** (`cargo clippy --all-targets --all-features`)
✅ **Code formatted** (`cargo fmt --check`)
✅ **Release build succeeds** (`cargo build --release --all-features`)
✅ **All examples compile** (`cargo build --examples`)
✅ **No breaking changes** - existing API unchanged, new methods are additions only

## Design Decisions

1. **Followed existing `BorrowedVideoFrame` pattern from send path** - consistency across the crate
2. **Made borrowed types `!Send`** - prevents accidental misuse of FFI buffers across threads
3. **Comprehensive accessor methods** - match owned types' API surface for ergonomics
4. **Single `to_owned()` conversion point** - all owned captures delegate to borrowed + `to_owned()`
5. **Zero unsafe code added** - only uses existing safe `RecvGuard` abstractions

## Acceptance Criteria (from Issue #23)

✅ 1. `capture_*_ref` returns zero-allocation, zero-copy borrowed frames on the hot path
✅ 2. Existing `capture_*` (owned) uses the new borrowed path internally; behavior preserved
✅ 3. No UB: exactly one `NDIlib_recv_free_*` per borrowed frame via `Drop`. No double frees
✅ 4. Borrowed types document `!Send` and that lifetime is limited to the caller scope
✅ 5. Performance improvement (saves ~8.3 MB memcpy per 1080p frame)

## Files Modified

- `src/frames.rs` (+439 lines) - Borrowed frame types
- `src/receiver.rs` (+198 lines, -18 lines) - New `capture_*_ref` methods
- `src/lib.rs` (+3 exports) - Public API additions

## Code Quality

- No new unsafe code (only uses existing safe `RecvGuard` abstractions)
- Full rustdoc on all public items with examples
- Follows existing crate conventions
- Zero clippy warnings
- All tests pass

---

Closes #23