### PR TITLE
feat!: API stabilization for 1.0 (Issue #24 - All 8 Steps Complete)

### DIFF
--- a/examples/NDIlib_Find.rs
+++ b/examples/NDIlib_Find.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), Error> {
     println!("(Will run for 60 seconds)\n");
 
     // Check for initial sources immediately
-    let initial_sources = finder.get_sources(0)?;
+    let initial_sources = finder.sources(Duration::ZERO)?;
     if !initial_sources.is_empty() {
         println!("Initial sources found ({}):", initial_sources.len());
         for (i, source) in initial_sources.iter().enumerate() {
@@ -70,7 +70,7 @@ fn main() -> Result<(), Error> {
 
     while start.elapsed() < Duration::from_secs(60) {
         // Wait up to 5 seconds for sources to be added or removed
-        if !finder.wait_for_sources(5000) {
+        if !finder.wait_for_sources(Duration::from_secs(5))? {
             // No changes detected
             let elapsed = start.elapsed().as_secs();
             if elapsed % 10 == 0 {
@@ -84,7 +84,7 @@ fn main() -> Result<(), Error> {
         }
 
         // Get the updated list of sources
-        let sources = finder.get_sources(0)?;
+        let sources = finder.sources(Duration::ZERO)?;
         let elapsed = start.elapsed().as_secs();
 
         // Display changes

--- a/examples/NDIlib_Recv_Audio.rs
+++ b/examples/NDIlib_Recv_Audio.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Error> {
 
     // Capture a few audio frames
     for i in 0..5 {
-        match receiver.capture_audio(Duration::from_secs(5))? {
+        match receiver.capture_audio_timeout(Duration::from_secs(5))? {
             Some(audio_frame) => {
                 println!("Frame {}: ", i + 1);
                 println!("  Sample rate: {} Hz", audio_frame.sample_rate);

--- a/examples/NDIlib_Recv_Audio.rs
+++ b/examples/NDIlib_Recv_Audio.rs
@@ -10,7 +10,9 @@
 
 use std::{thread, time::Duration};
 
-use grafton_ndi::{Error, Finder, FinderOptions, ReceiverBandwidth, ReceiverOptions, NDI};
+use grafton_ndi::{
+    Error, Finder, FinderOptions, Receiver, ReceiverBandwidth, ReceiverOptions, NDI,
+};
 
 fn main() -> Result<(), Error> {
     println!("NDI Audio Receiver Example (32-bit float)");
@@ -47,10 +49,11 @@ fn main() -> Result<(), Error> {
     println!("Connecting to: {}\n", source);
 
     // Create a receiver for audio
-    let receiver = ReceiverOptions::builder(source)
+    let options = ReceiverOptions::builder(source)
         .bandwidth(ReceiverBandwidth::AudioOnly)
         .name("Audio Capture Example")
-        .build(&ndi)?;
+        .build();
+    let receiver = Receiver::new(&ndi, &options)?;
 
     println!("Receiver created successfully");
     println!("Waiting for audio frames...\n");

--- a/examples/NDIlib_Recv_Audio.rs
+++ b/examples/NDIlib_Recv_Audio.rs
@@ -27,8 +27,8 @@ fn main() -> Result<(), Error> {
 
     // Wait for sources to appear
     println!("Searching for NDI sources...\n");
-    finder.wait_for_sources(5000);
-    let sources = finder.get_sources(5000)?;
+    finder.wait_for_sources(Duration::from_secs(5))?;
+    let sources = finder.sources(Duration::from_secs(5))?;
 
     if sources.is_empty() {
         println!("No NDI sources found!");
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
 
     // Capture a few audio frames
     for i in 0..5 {
-        match receiver.capture_audio(5000)? {
+        match receiver.capture_audio(Duration::from_secs(5))? {
             Some(audio_frame) => {
                 println!("Frame {}: ", i + 1);
                 println!("  Sample rate: {} Hz", audio_frame.sample_rate);

--- a/examples/NDIlib_Recv_Audio.rs
+++ b/examples/NDIlib_Recv_Audio.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Error> {
                 println!("  Channels: {}", audio_frame.num_channels);
                 println!("  Samples: {}", audio_frame.num_samples);
                 println!("  Timestamp: {}", audio_frame.timestamp);
-                println!("  Format: {:?}", audio_frame.fourcc);
+                println!("  Format: {:?}", audio_frame.format);
 
                 // Get the audio data as f32
                 let audio_data = audio_frame.data();

--- a/examples/NDIlib_Recv_Audio_16bpp.rs
+++ b/examples/NDIlib_Recv_Audio_16bpp.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example NDIlib_Recv_Audio_16bpp`
 
-use grafton_ndi::{Error, Finder, FinderOptions, ReceiverOptions, NDI};
+use grafton_ndi::{Error, Finder, FinderOptions, Receiver, ReceiverOptions, NDI};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -40,9 +40,10 @@ fn main() -> Result<(), Error> {
     };
 
     // Create a receiver for the first source
-    let receiver = ReceiverOptions::builder(sources[0].clone())
+    let options = ReceiverOptions::builder(sources[0].clone())
         .name("Example Audio Converter Receiver")
-        .build(&ndi)?;
+        .build();
+    let receiver = Receiver::new(&ndi, &options)?;
 
     // Run for one minute
     let start = Instant::now();

--- a/examples/NDIlib_Recv_Audio_16bpp.rs
+++ b/examples/NDIlib_Recv_Audio_16bpp.rs
@@ -32,8 +32,8 @@ fn main() -> Result<(), Error> {
         if exit_loop.load(Ordering::Relaxed) {
             return Ok(());
         }
-        finder.wait_for_sources(1000);
-        let sources = finder.get_sources(0)?;
+        finder.wait_for_sources(Duration::from_secs(1))?;
+        let sources = finder.sources(Duration::ZERO)?;
         if !sources.is_empty() {
             break sources;
         }
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
     let start = Instant::now();
     while !exit_loop.load(Ordering::Relaxed) && start.elapsed() < Duration::from_secs(60) {
         // Check for video frames
-        if let Some(video_frame) = receiver.capture_video(0)? {
+        if let Some(video_frame) = receiver.capture_video(Duration::ZERO)? {
             println!(
                 "Video data received ({width}x{height}).",
                 width = video_frame.width,
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
         }
 
         // Check for audio frames
-        if let Some(audio_frame) = receiver.capture_audio(0)? {
+        if let Some(audio_frame) = receiver.capture_audio(Duration::ZERO)? {
             println!(
                 "Audio data received ({num_samples} samples).",
                 num_samples = audio_frame.num_samples
@@ -74,12 +74,12 @@ fn main() -> Result<(), Error> {
         }
 
         // Check for metadata
-        if let Some(_metadata) = receiver.capture_metadata(0)? {
+        if let Some(_metadata) = receiver.capture_metadata(Duration::ZERO)? {
             println!("Meta data received.");
         }
 
         // Check for status changes
-        if let Some(_status) = receiver.poll_status_change(0) {
+        if let Some(_status) = receiver.poll_status_change(Duration::ZERO)? {
             println!("Receiver connection status changed.");
         }
 

--- a/examples/NDIlib_Recv_Audio_16bpp.rs
+++ b/examples/NDIlib_Recv_Audio_16bpp.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Error> {
     let start = Instant::now();
     while !exit_loop.load(Ordering::Relaxed) && start.elapsed() < Duration::from_secs(60) {
         // Check for video frames
-        if let Some(video_frame) = receiver.capture_video(Duration::ZERO)? {
+        if let Some(video_frame) = receiver.capture_video_timeout(Duration::ZERO)? {
             println!(
                 "Video data received ({width}x{height}).",
                 width = video_frame.width,
@@ -58,7 +58,7 @@ fn main() -> Result<(), Error> {
         }
 
         // Check for audio frames
-        if let Some(audio_frame) = receiver.capture_audio(Duration::ZERO)? {
+        if let Some(audio_frame) = receiver.capture_audio_timeout(Duration::ZERO)? {
             println!(
                 "Audio data received ({num_samples} samples).",
                 num_samples = audio_frame.num_samples
@@ -75,7 +75,7 @@ fn main() -> Result<(), Error> {
         }
 
         // Check for metadata
-        if let Some(_metadata) = receiver.capture_metadata(Duration::ZERO)? {
+        if let Some(_metadata) = receiver.capture_metadata_timeout(Duration::ZERO)? {
             println!("Meta data received.");
         }
 

--- a/examples/NDIlib_Recv_PNG.rs
+++ b/examples/NDIlib_Recv_PNG.rs
@@ -22,7 +22,8 @@
 //! - Both: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100 --output MyImage.png`
 
 use grafton_ndi::{
-    Error, Finder, FinderOptions, FourCCVideoType, ReceiverColorFormat, ReceiverOptions, NDI,
+    Error, Finder, FinderOptions, FourCCVideoType, Receiver, ReceiverColorFormat, ReceiverOptions,
+    NDI,
 };
 
 use std::{
@@ -90,9 +91,10 @@ fn main() -> Result<(), Error> {
 
     let first_source = &sources[0];
     println!("\nCreating receiver for: {first_source}");
-    let receiver = ReceiverOptions::builder(sources[0].clone())
+    let options = ReceiverOptions::builder(sources[0].clone())
         .color(ReceiverColorFormat::RGBX_RGBA)
-        .build(&ndi)?;
+        .build();
+    let receiver = Receiver::new(&ndi, &options)?;
 
     println!("Receiver created successfully");
     println!("Waiting for video frames...\n");

--- a/examples/NDIlib_Recv_PNG.rs
+++ b/examples/NDIlib_Recv_PNG.rs
@@ -25,7 +25,11 @@ use grafton_ndi::{
     Error, Finder, FinderOptions, FourCCVideoType, ReceiverColorFormat, ReceiverOptions, NDI,
 };
 
-use std::{env, fs::File, time::Instant};
+use std::{
+    env,
+    fs::File,
+    time::{Duration, Instant},
+};
 
 fn main() -> Result<(), Error> {
     let args: Vec<String> = env::args().collect();
@@ -71,8 +75,8 @@ fn main() -> Result<(), Error> {
 
     println!("Looking for sources ...");
     let sources = loop {
-        finder.wait_for_sources(1000);
-        let sources = finder.get_sources(0)?;
+        finder.wait_for_sources(Duration::from_secs(1))?;
+        let sources = finder.sources(Duration::ZERO)?;
         if !sources.is_empty() {
             let count = sources.len();
             println!("Found {count} source(s):");
@@ -94,7 +98,7 @@ fn main() -> Result<(), Error> {
     println!("Waiting for video frames...\n");
 
     let start_time = Instant::now();
-    let video_frame = receiver.capture_video_blocking(60_000)?;
+    let video_frame = receiver.capture_video_blocking(Duration::from_secs(60))?;
 
     let elapsed = start_time.elapsed();
     println!("Frame received after {elapsed:?}");

--- a/examples/NDIlib_Recv_PTZ.rs
+++ b/examples/NDIlib_Recv_PTZ.rs
@@ -46,8 +46,8 @@ fn main() -> Result<(), Error> {
         if exit_loop.load(Ordering::Relaxed) {
             return Ok(());
         }
-        finder.wait_for_sources(1000);
-        let sources = finder.get_sources(0)?;
+        finder.wait_for_sources(Duration::from_secs(1))?;
+        let sources = finder.sources(Duration::ZERO)?;
         if !sources.is_empty() {
             break sources;
         }
@@ -62,7 +62,7 @@ fn main() -> Result<(), Error> {
     let start = Instant::now();
     while !exit_loop.load(Ordering::Relaxed) && start.elapsed() < Duration::from_secs(30) {
         // Use poll_status_change to check for status changes
-        if let Some(_status) = receiver.poll_status_change(1000) {
+        if let Some(_status) = receiver.poll_status_change(Duration::from_secs(1))? {
             // Check PTZ support on status change
             if receiver.ptz_is_supported() {
                 println!("This source supports PTZ functionality. Moving to preset #3.");

--- a/examples/NDIlib_Recv_PTZ.rs
+++ b/examples/NDIlib_Recv_PTZ.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example NDIlib_Recv_PTZ`
 
-use grafton_ndi::{Error, Finder, FinderOptions, ReceiverOptions, NDI};
+use grafton_ndi::{Error, Finder, FinderOptions, Receiver, ReceiverOptions, NDI};
 
 use std::{
     sync::{
@@ -54,9 +54,10 @@ fn main() -> Result<(), Error> {
     };
 
     // Create a receiver for the first source
-    let receiver = ReceiverOptions::builder(sources[0].clone())
+    let options = ReceiverOptions::builder(sources[0].clone())
         .name("Example PTZ Receiver")
-        .build(&ndi)?;
+        .build();
+    let receiver = Receiver::new(&ndi, &options)?;
 
     // Run for 30 seconds
     let start = Instant::now();

--- a/examples/NDIlib_Send_Audio.rs
+++ b/examples/NDIlib_Send_Audio.rs
@@ -25,9 +25,7 @@ fn main() -> Result<(), Error> {
     let ndi = NDI::new()?;
 
     // Create an NDI source that is clocked to audio
-    let send_options = SenderOptions::builder("My Audio")
-        .clock_audio(true)
-        .build()?;
+    let send_options = SenderOptions::builder("My Audio").clock_audio(true).build();
 
     let sender = Sender::new(&ndi, &send_options)?;
 

--- a/examples/NDIlib_Send_Video.rs
+++ b/examples/NDIlib_Send_Video.rs
@@ -8,7 +8,7 @@
 
 use std::time::Instant;
 
-use grafton_ndi::{Error, FourCCVideoType, Sender, SenderOptions, VideoFrame, NDI};
+use grafton_ndi::{Error, PixelFormat, Sender, SenderOptions, VideoFrame, NDI};
 
 fn main() -> Result<(), Error> {
     // Initialize NDI
@@ -32,7 +32,7 @@ fn main() -> Result<(), Error> {
             // Create video frame with test pattern
             let video_frame = VideoFrame::builder()
                 .resolution(xres, yres)
-                .fourcc(FourCCVideoType::BGRX)
+                .pixel_format(PixelFormat::BGRX)
                 .build()?;
 
             // The frame is created with zero-initialized data

--- a/examples/NDIlib_Send_Video.rs
+++ b/examples/NDIlib_Send_Video.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Error> {
     let ndi = NDI::new()?;
 
     // Create the NDI sender
-    let send_options = SenderOptions::builder("My Video").build()?;
+    let send_options = SenderOptions::builder("My Video").build();
     let sender = Sender::new(&ndi, &send_options)?;
 
     // We are going to create a 1920x1080 frame at 29.97Hz

--- a/examples/async_send.rs
+++ b/examples/async_send.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use grafton_ndi::{BorrowedVideoFrame, FourCCVideoType, SenderOptions, NDI};
+use grafton_ndi::{BorrowedVideoFrame, PixelFormat, SenderOptions, NDI};
 
 fn main() -> Result<(), grafton_ndi::Error> {
     // Initialize NDI
@@ -42,14 +42,8 @@ fn main() -> Result<(), grafton_ndi::Error> {
             pixel[3] = 255; // A
         }
 
-        let frame = BorrowedVideoFrame::from_buffer(
-            &video_buffer,
-            1920,
-            1080,
-            FourCCVideoType::BGRA,
-            30,
-            1,
-        );
+        let frame =
+            BorrowedVideoFrame::from_buffer(&video_buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
 
         println!("Sending video frame...");
         let start = Instant::now();
@@ -88,7 +82,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
         println!("Sending 3 video frames sequentially...");
         for (idx, buffer) in buffers.iter().enumerate() {
             let frame =
-                BorrowedVideoFrame::from_buffer(buffer, 1920, 1080, FourCCVideoType::BGRA, 30, 1);
+                BorrowedVideoFrame::from_buffer(buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
 
             let frame_num = idx + 1;
             println!("Sending frame {frame_num}...");

--- a/examples/async_send.rs
+++ b/examples/async_send.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
     let send_options = SenderOptions::builder("AsyncExample")
         .clock_video(true)
         .clock_audio(true)
-        .build()?;
+        .build();
     let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
     println!("Created NDI sender: AsyncExample");

--- a/examples/concurrent_capture.rs
+++ b/examples/concurrent_capture.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
             let mut frame_count = 0;
 
             for _ in 0..10 {
-                match recv_video.capture_video(Duration::from_secs(5)) {
+                match recv_video.capture_video_timeout(Duration::from_secs(5)) {
                     Ok(Some(frame)) => {
                         frame_count += 1;
                         let width = frame.width;
@@ -89,7 +89,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
             let mut sample_count = 0;
 
             for _ in 0..10 {
-                match recv_audio.capture_audio(Duration::from_secs(5)) {
+                match recv_audio.capture_audio_timeout(Duration::from_secs(5)) {
                     Ok(Some(frame)) => {
                         sample_count += frame.num_samples;
                         let num_samples = frame.num_samples;
@@ -120,7 +120,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
             let mut metadata_count = 0;
 
             for _ in 0..20 {
-                match recv_metadata.capture_metadata(Duration::from_millis(2500)) {
+                match recv_metadata.capture_metadata_timeout(Duration::from_millis(2500)) {
                     Ok(Some(frame)) => {
                         metadata_count += 1;
                         let data_len = frame.data.len();

--- a/examples/concurrent_capture.rs
+++ b/examples/concurrent_capture.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, thread, time::Duration};
 
-use grafton_ndi::{ReceiverBandwidth, ReceiverColorFormat, ReceiverOptions, NDI};
+use grafton_ndi::{Receiver, ReceiverBandwidth, ReceiverColorFormat, ReceiverOptions, NDI};
 
 fn main() -> Result<(), grafton_ndi::Error> {
     // Initialize NDI
@@ -37,12 +37,13 @@ fn main() -> Result<(), grafton_ndi::Error> {
     println!("\nConnecting to: {source}");
 
     // Create receiver
-    let receiver = ReceiverOptions::builder(source)
+    let options = ReceiverOptions::builder(source)
         .color(ReceiverColorFormat::BGRX_BGRA)
         .bandwidth(ReceiverBandwidth::Highest)
         .allow_video_fields(true)
         .name("Concurrent Capture Example")
-        .build(&ndi)?;
+        .build();
+    let receiver = Receiver::new(&ndi, &options)?;
 
     // Wrap receiver in Arc for sharing between threads
     let receiver = Arc::new(receiver);

--- a/examples/concurrent_capture.rs
+++ b/examples/concurrent_capture.rs
@@ -14,13 +14,13 @@ fn main() -> Result<(), grafton_ndi::Error> {
 
     // Wait for sources
     println!("Looking for NDI sources...");
-    if !finder.wait_for_sources(5000) {
+    if !finder.wait_for_sources(Duration::from_secs(5))? {
         println!("No sources found after 5 seconds");
         return Ok(());
     }
 
     // Get available sources
-    let sources = finder.get_sources(0)?;
+    let sources = finder.sources(Duration::ZERO)?;
     if sources.is_empty() {
         println!("No NDI sources found on the network");
         return Ok(());
@@ -56,7 +56,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
             let mut frame_count = 0;
 
             for _ in 0..10 {
-                match recv_video.capture_video(5000) {
+                match recv_video.capture_video(Duration::from_secs(5)) {
                     Ok(Some(frame)) => {
                         frame_count += 1;
                         let width = frame.width;
@@ -88,7 +88,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
             let mut sample_count = 0;
 
             for _ in 0..10 {
-                match recv_audio.capture_audio(5000) {
+                match recv_audio.capture_audio(Duration::from_secs(5)) {
                     Ok(Some(frame)) => {
                         sample_count += frame.num_samples;
                         let num_samples = frame.num_samples;
@@ -119,7 +119,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
             let mut metadata_count = 0;
 
             for _ in 0..20 {
-                match recv_metadata.capture_metadata(2500) {
+                match recv_metadata.capture_metadata(Duration::from_millis(2500)) {
                     Ok(Some(frame)) => {
                         metadata_count += 1;
                         let data_len = frame.data.len();

--- a/examples/status_monitor.rs
+++ b/examples/status_monitor.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use grafton_ndi::{Finder, FinderOptions, ReceiverBandwidth, ReceiverOptions, NDI};
+use grafton_ndi::{Finder, FinderOptions, Receiver, ReceiverBandwidth, ReceiverOptions, NDI};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command line arguments
@@ -48,9 +48,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Create receiver with metadata-only bandwidth to focus on status changes
-    let receiver = ReceiverOptions::builder(source.clone())
+    let options = ReceiverOptions::builder(source.clone())
         .bandwidth(ReceiverBandwidth::MetadataOnly)
-        .build(&ndi)?;
+        .build();
+    let receiver = Receiver::new(&ndi, &options)?;
 
     println!("\nMonitoring status changes for: {}", source);
     println!("Press Ctrl+C to exit\n");

--- a/examples/status_monitor.rs
+++ b/examples/status_monitor.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     io::{self, Write},
+    time::Duration,
 };
 
 use grafton_ndi::{Finder, FinderOptions, ReceiverBandwidth, ReceiverOptions, NDI};
@@ -23,8 +24,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let finder = Finder::new(&ndi, &finder_options)?;
 
     println!("Looking for NDI sources...");
-    finder.wait_for_sources(5000);
-    let sources = finder.get_sources(0)?;
+    finder.wait_for_sources(Duration::from_secs(5))?;
+    let sources = finder.sources(Duration::ZERO)?;
 
     if sources.is_empty() {
         println!("No NDI sources found on the network");
@@ -56,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Monitor status changes
     loop {
-        if let Some(status) = receiver.poll_status_change(1000) {
+        if let Some(status) = receiver.poll_status_change(Duration::from_secs(1))? {
             print!("[Status Change] ");
 
             if let Some(tally) = status.tally {

--- a/examples/zero_copy_send.rs
+++ b/examples/zero_copy_send.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
         .build();
     let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
-    let source_name = sender.get_source_name()?;
+    let source_name = sender.source()?;
     println!("Created NDI sender: {source_name}");
 
     // Pre-allocate a single buffer (demonstrating single-buffer with callback)

--- a/examples/zero_copy_send.rs
+++ b/examples/zero_copy_send.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
     let send_options = SenderOptions::builder("Zero-Copy Sender Example")
         .clock_video(true)
         .clock_audio(true)
-        .build()?;
+        .build();
     let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
     let source_name = sender.get_source_name()?;

--- a/examples/zero_copy_send.rs
+++ b/examples/zero_copy_send.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use grafton_ndi::{BorrowedVideoFrame, FourCCVideoType, SenderOptions, NDI};
+use grafton_ndi::{BorrowedVideoFrame, PixelFormat, SenderOptions, NDI};
 
 fn main() -> Result<(), grafton_ndi::Error> {
     // Initialize NDI
@@ -68,7 +68,7 @@ fn main() -> Result<(), grafton_ndi::Error> {
 
         // Create a borrowed frame that references our buffer
         let borrowed_frame =
-            BorrowedVideoFrame::from_buffer(&buffer, width, height, FourCCVideoType::BGRA, 60, 1);
+            BorrowedVideoFrame::from_buffer(&buffer, width, height, PixelFormat::BGRA, 60, 1);
 
         // Send asynchronously - no copy happens here!
         let _token = sender.send_video_async(&borrowed_frame);

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -42,7 +42,7 @@
 //! # }
 //! ```
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     frames::{AudioFrame, MetadataFrame, VideoFrame},
@@ -118,16 +118,17 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout in milliseconds for the capture attempt
+        /// * `timeout` - Timeout duration for the capture attempt.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
         /// * `Ok(Some(frame))` - Successfully captured a video frame
         /// * `Ok(None)` - No frame available within timeout
         /// * `Err(_)` - An error occurred during capture
-        pub async fn capture_video(&self, timeout_ms: u32) -> Result<Option<VideoFrame>> {
+        pub async fn capture_video(&self, timeout: Duration) -> Result<Option<VideoFrame>> {
             let receiver = Arc::clone(&self.inner);
-            ::tokio::task::spawn_blocking(move || receiver.capture_video(timeout_ms))
+            ::tokio::task::spawn_blocking(move || receiver.capture_video(timeout))
                 .await
                 .expect("Blocking task panicked")
         }
@@ -138,7 +139,7 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout for each capture attempt in milliseconds
+        /// * `timeout` - Timeout for each capture attempt. Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         /// * `max_attempts` - Maximum number of retry attempts
         ///
         /// # Returns
@@ -148,12 +149,12 @@ pub mod tokio {
         /// * `Err(_)` - An error occurred during capture
         pub async fn capture_video_with_retry(
             &self,
-            timeout_ms: u32,
+            timeout: Duration,
             max_attempts: usize,
         ) -> Result<Option<VideoFrame>> {
             let receiver = Arc::clone(&self.inner);
             ::tokio::task::spawn_blocking(move || {
-                receiver.capture_video_with_retry(timeout_ms, max_attempts)
+                receiver.capture_video_with_retry(timeout, max_attempts)
             })
             .await
             .expect("Blocking task panicked")
@@ -166,7 +167,8 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `total_timeout_ms` - Total time to wait for a frame in milliseconds
+        /// * `total_timeout` - Total time to wait for a frame.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
@@ -195,9 +197,9 @@ pub mod tokio {
         /// # }
         /// # }
         /// ```
-        pub async fn capture_video_blocking(&self, total_timeout_ms: u32) -> Result<VideoFrame> {
+        pub async fn capture_video_blocking(&self, total_timeout: Duration) -> Result<VideoFrame> {
             let receiver = Arc::clone(&self.inner);
-            ::tokio::task::spawn_blocking(move || receiver.capture_video_blocking(total_timeout_ms))
+            ::tokio::task::spawn_blocking(move || receiver.capture_video_blocking(total_timeout))
                 .await
                 .expect("Blocking task panicked")
         }
@@ -215,9 +217,9 @@ pub mod tokio {
         /// * `Ok(Some(frame))` - Successfully captured an audio frame
         /// * `Ok(None)` - No frame available within timeout
         /// * `Err(_)` - An error occurred during capture
-        pub async fn capture_audio(&self, timeout_ms: u32) -> Result<Option<AudioFrame>> {
+        pub async fn capture_audio(&self, timeout: Duration) -> Result<Option<AudioFrame>> {
             let receiver = Arc::clone(&self.inner);
-            ::tokio::task::spawn_blocking(move || receiver.capture_audio(timeout_ms))
+            ::tokio::task::spawn_blocking(move || receiver.capture_audio(timeout))
                 .await
                 .expect("Blocking task panicked")
         }
@@ -228,7 +230,7 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout for each capture attempt in milliseconds
+        /// * `timeout` - Timeout for each capture attempt. Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         /// * `max_attempts` - Maximum number of retry attempts
         ///
         /// # Returns
@@ -238,12 +240,12 @@ pub mod tokio {
         /// * `Err(_)` - An error occurred during capture
         pub async fn capture_audio_with_retry(
             &self,
-            timeout_ms: u32,
+            timeout: Duration,
             max_attempts: usize,
         ) -> Result<Option<AudioFrame>> {
             let receiver = Arc::clone(&self.inner);
             ::tokio::task::spawn_blocking(move || {
-                receiver.capture_audio_with_retry(timeout_ms, max_attempts)
+                receiver.capture_audio_with_retry(timeout, max_attempts)
             })
             .await
             .expect("Blocking task panicked")
@@ -256,16 +258,17 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `total_timeout_ms` - Total time to wait for a frame in milliseconds
+        /// * `total_timeout` - Total time to wait for a frame.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
         /// * `Ok(frame)` - Successfully captured an audio frame
         /// * `Err(Error::FrameTimeout)` - No frame received within timeout (includes retry details)
         /// * `Err(_)` - Another error occurred during capture
-        pub async fn capture_audio_blocking(&self, total_timeout_ms: u32) -> Result<AudioFrame> {
+        pub async fn capture_audio_blocking(&self, total_timeout: Duration) -> Result<AudioFrame> {
             let receiver = Arc::clone(&self.inner);
-            ::tokio::task::spawn_blocking(move || receiver.capture_audio_blocking(total_timeout_ms))
+            ::tokio::task::spawn_blocking(move || receiver.capture_audio_blocking(total_timeout))
                 .await
                 .expect("Blocking task panicked")
         }
@@ -283,9 +286,9 @@ pub mod tokio {
         /// * `Ok(Some(frame))` - Successfully captured a metadata frame
         /// * `Ok(None)` - No frame available within timeout
         /// * `Err(_)` - An error occurred during capture
-        pub async fn capture_metadata(&self, timeout_ms: u32) -> Result<Option<MetadataFrame>> {
+        pub async fn capture_metadata(&self, timeout: Duration) -> Result<Option<MetadataFrame>> {
             let receiver = Arc::clone(&self.inner);
-            ::tokio::task::spawn_blocking(move || receiver.capture_metadata(timeout_ms))
+            ::tokio::task::spawn_blocking(move || receiver.capture_metadata(timeout))
                 .await
                 .expect("Blocking task panicked")
         }
@@ -296,7 +299,7 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout for each capture attempt in milliseconds
+        /// * `timeout` - Timeout for each capture attempt. Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         /// * `max_attempts` - Maximum number of retry attempts
         ///
         /// # Returns
@@ -306,12 +309,12 @@ pub mod tokio {
         /// * `Err(_)` - An error occurred during capture
         pub async fn capture_metadata_with_retry(
             &self,
-            timeout_ms: u32,
+            timeout: Duration,
             max_attempts: usize,
         ) -> Result<Option<MetadataFrame>> {
             let receiver = Arc::clone(&self.inner);
             ::tokio::task::spawn_blocking(move || {
-                receiver.capture_metadata_with_retry(timeout_ms, max_attempts)
+                receiver.capture_metadata_with_retry(timeout, max_attempts)
             })
             .await
             .expect("Blocking task panicked")
@@ -324,7 +327,8 @@ pub mod tokio {
         ///
         /// # Arguments
         ///
-        /// * `total_timeout_ms` - Total time to wait for a frame in milliseconds
+        /// * `total_timeout` - Total time to wait for a frame.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
@@ -333,14 +337,12 @@ pub mod tokio {
         /// * `Err(_)` - Another error occurred during capture
         pub async fn capture_metadata_blocking(
             &self,
-            total_timeout_ms: u32,
+            total_timeout: Duration,
         ) -> Result<MetadataFrame> {
             let receiver = Arc::clone(&self.inner);
-            ::tokio::task::spawn_blocking(move || {
-                receiver.capture_metadata_blocking(total_timeout_ms)
-            })
-            .await
-            .expect("Blocking task panicked")
+            ::tokio::task::spawn_blocking(move || receiver.capture_metadata_blocking(total_timeout))
+                .await
+                .expect("Blocking task panicked")
         }
     }
 
@@ -429,9 +431,9 @@ pub mod async_std {
         /// * `Ok(Some(frame))` - Successfully captured a video frame
         /// * `Ok(None)` - No frame available within timeout
         /// * `Err(_)` - An error occurred during capture
-        pub async fn capture_video(&self, timeout_ms: u32) -> Result<Option<VideoFrame>> {
+        pub async fn capture_video(&self, timeout: Duration) -> Result<Option<VideoFrame>> {
             let receiver = Arc::clone(&self.inner);
-            ::async_std::task::spawn_blocking(move || receiver.capture_video(timeout_ms)).await
+            ::async_std::task::spawn_blocking(move || receiver.capture_video(timeout)).await
         }
 
         /// Async version of `Receiver::capture_video_with_retry`.
@@ -440,7 +442,7 @@ pub mod async_std {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout for each capture attempt in milliseconds
+        /// * `timeout` - Timeout for each capture attempt. Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         /// * `max_attempts` - Maximum number of retry attempts
         ///
         /// # Returns
@@ -450,12 +452,12 @@ pub mod async_std {
         /// * `Err(_)` - An error occurred during capture
         pub async fn capture_video_with_retry(
             &self,
-            timeout_ms: u32,
+            timeout: Duration,
             max_attempts: usize,
         ) -> Result<Option<VideoFrame>> {
             let receiver = Arc::clone(&self.inner);
             ::async_std::task::spawn_blocking(move || {
-                receiver.capture_video_with_retry(timeout_ms, max_attempts)
+                receiver.capture_video_with_retry(timeout, max_attempts)
             })
             .await
         }
@@ -467,7 +469,8 @@ pub mod async_std {
         ///
         /// # Arguments
         ///
-        /// * `total_timeout_ms` - Total time to wait for a frame in milliseconds
+        /// * `total_timeout` - Total time to wait for a frame.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
@@ -496,10 +499,10 @@ pub mod async_std {
         /// # }
         /// # }
         /// ```
-        pub async fn capture_video_blocking(&self, total_timeout_ms: u32) -> Result<VideoFrame> {
+        pub async fn capture_video_blocking(&self, total_timeout: Duration) -> Result<VideoFrame> {
             let receiver = Arc::clone(&self.inner);
             ::async_std::task::spawn_blocking(move || {
-                receiver.capture_video_blocking(total_timeout_ms)
+                receiver.capture_video_blocking(total_timeout)
             })
             .await
         }
@@ -517,9 +520,9 @@ pub mod async_std {
         /// * `Ok(Some(frame))` - Successfully captured an audio frame
         /// * `Ok(None)` - No frame available within timeout
         /// * `Err(_)` - An error occurred during capture
-        pub async fn capture_audio(&self, timeout_ms: u32) -> Result<Option<AudioFrame>> {
+        pub async fn capture_audio(&self, timeout: Duration) -> Result<Option<AudioFrame>> {
             let receiver = Arc::clone(&self.inner);
-            ::async_std::task::spawn_blocking(move || receiver.capture_audio(timeout_ms)).await
+            ::async_std::task::spawn_blocking(move || receiver.capture_audio(timeout)).await
         }
 
         /// Async version of `Receiver::capture_audio_with_retry`.
@@ -528,7 +531,7 @@ pub mod async_std {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout for each capture attempt in milliseconds
+        /// * `timeout` - Timeout for each capture attempt. Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         /// * `max_attempts` - Maximum number of retry attempts
         ///
         /// # Returns
@@ -538,12 +541,12 @@ pub mod async_std {
         /// * `Err(_)` - An error occurred during capture
         pub async fn capture_audio_with_retry(
             &self,
-            timeout_ms: u32,
+            timeout: Duration,
             max_attempts: usize,
         ) -> Result<Option<AudioFrame>> {
             let receiver = Arc::clone(&self.inner);
             ::async_std::task::spawn_blocking(move || {
-                receiver.capture_audio_with_retry(timeout_ms, max_attempts)
+                receiver.capture_audio_with_retry(timeout, max_attempts)
             })
             .await
         }
@@ -555,17 +558,18 @@ pub mod async_std {
         ///
         /// # Arguments
         ///
-        /// * `total_timeout_ms` - Total time to wait for a frame in milliseconds
+        /// * `total_timeout` - Total time to wait for a frame.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
         /// * `Ok(frame)` - Successfully captured an audio frame
         /// * `Err(Error::FrameTimeout)` - No frame received within timeout (includes retry details)
         /// * `Err(_)` - Another error occurred during capture
-        pub async fn capture_audio_blocking(&self, total_timeout_ms: u32) -> Result<AudioFrame> {
+        pub async fn capture_audio_blocking(&self, total_timeout: Duration) -> Result<AudioFrame> {
             let receiver = Arc::clone(&self.inner);
             ::async_std::task::spawn_blocking(move || {
-                receiver.capture_audio_blocking(total_timeout_ms)
+                receiver.capture_audio_blocking(total_timeout)
             })
             .await
         }
@@ -583,9 +587,9 @@ pub mod async_std {
         /// * `Ok(Some(frame))` - Successfully captured a metadata frame
         /// * `Ok(None)` - No frame available within timeout
         /// * `Err(_)` - An error occurred during capture
-        pub async fn capture_metadata(&self, timeout_ms: u32) -> Result<Option<MetadataFrame>> {
+        pub async fn capture_metadata(&self, timeout: Duration) -> Result<Option<MetadataFrame>> {
             let receiver = Arc::clone(&self.inner);
-            ::async_std::task::spawn_blocking(move || receiver.capture_metadata(timeout_ms)).await
+            ::async_std::task::spawn_blocking(move || receiver.capture_metadata(timeout)).await
         }
 
         /// Async version of `Receiver::capture_metadata_with_retry`.
@@ -594,7 +598,7 @@ pub mod async_std {
         ///
         /// # Arguments
         ///
-        /// * `timeout_ms` - Timeout for each capture attempt in milliseconds
+        /// * `timeout` - Timeout for each capture attempt. Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         /// * `max_attempts` - Maximum number of retry attempts
         ///
         /// # Returns
@@ -604,12 +608,12 @@ pub mod async_std {
         /// * `Err(_)` - An error occurred during capture
         pub async fn capture_metadata_with_retry(
             &self,
-            timeout_ms: u32,
+            timeout: Duration,
             max_attempts: usize,
         ) -> Result<Option<MetadataFrame>> {
             let receiver = Arc::clone(&self.inner);
             ::async_std::task::spawn_blocking(move || {
-                receiver.capture_metadata_with_retry(timeout_ms, max_attempts)
+                receiver.capture_metadata_with_retry(timeout, max_attempts)
             })
             .await
         }
@@ -621,7 +625,8 @@ pub mod async_std {
         ///
         /// # Arguments
         ///
-        /// * `total_timeout_ms` - Total time to wait for a frame in milliseconds
+        /// * `total_timeout` - Total time to wait for a frame.
+        ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
         ///
         /// # Returns
         ///
@@ -630,11 +635,11 @@ pub mod async_std {
         /// * `Err(_)` - Another error occurred during capture
         pub async fn capture_metadata_blocking(
             &self,
-            total_timeout_ms: u32,
+            total_timeout: Duration,
         ) -> Result<MetadataFrame> {
             let receiver = Arc::clone(&self.inner);
             ::async_std::task::spawn_blocking(move || {
-                receiver.capture_metadata_blocking(total_timeout_ms)
+                receiver.capture_metadata_blocking(total_timeout)
             })
             .await
         }

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -28,13 +28,13 @@
 //!     #     address: grafton_ndi::SourceAddress::None
 //!     # };
 //!
-//!     let receiver = ReceiverOptionsBuilder::snapshot_preset(source)
-//!         .build(&ndi)?;
+//!     let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+//!     let receiver = grafton_ndi::Receiver::new(&ndi, &options)?;
 //!
 //!     let async_receiver = AsyncReceiver::new(receiver);
 //!
 //!     // Capture frame asynchronously without blocking the runtime
-//!     let frame = async_receiver.capture_video_blocking(5000).await?;
+//!     let frame = async_receiver.capture_video(std::time::Duration::from_secs(5)).await?;
 //!     println!("Captured {}x{} frame", frame.width, frame.height);
 //!
 //!     Ok(())
@@ -84,11 +84,12 @@ pub mod tokio {
     ///     #     address: grafton_ndi::SourceAddress::None
     ///     # };
     ///
-    ///     let receiver = ReceiverOptionsBuilder::snapshot_preset(source).build(&ndi)?;
+    ///     let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+    ///     let receiver = grafton_ndi::Receiver::new(&ndi, &options)?;
     ///     let async_receiver = AsyncReceiver::new(receiver);
     ///
     ///     // Non-blocking async capture
-    ///     match async_receiver.capture_video(100).await? {
+    ///     match async_receiver.capture_video_timeout(std::time::Duration::from_millis(100)).await? {
     ///         Some(frame) => println!("Got frame: {}x{}", frame.width, frame.height),
     ///         None => println!("No frame available"),
     ///     }
@@ -319,11 +320,12 @@ pub mod async_std {
     ///     #     address: grafton_ndi::SourceAddress::None
     ///     # };
     ///
-    ///     let receiver = ReceiverOptionsBuilder::snapshot_preset(source).build(&ndi)?;
+    ///     let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+    ///     let receiver = grafton_ndi::Receiver::new(&ndi, &options)?;
     ///     let async_receiver = AsyncReceiver::new(receiver);
     ///
     ///     // Non-blocking async capture
-    ///     match async_receiver.capture_video(100).await? {
+    ///     match async_receiver.capture_video_timeout(std::time::Duration::from_millis(100)).await? {
     ///         Some(frame) => println!("Got frame: {}x{}", frame.width, frame.height),
     ///         None => println!("No frame available"),
     ///     }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -123,14 +123,15 @@ impl Default for FinderOptionsBuilder {
 ///
 /// ```no_run
 /// # use grafton_ndi::{NDI, FinderOptions, Finder};
+/// # use std::time::Duration;
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// let ndi = NDI::new()?;
 /// let options = FinderOptions::builder().show_local_sources(true).build();
 /// let finder = Finder::new(&ndi, &options)?;
 ///
 /// // Wait for initial discovery
-/// if finder.wait_for_sources(5000) {
-///     let sources = finder.get_sources(0)?;
+/// if finder.wait_for_sources(Duration::from_secs(5))? {
+///     let sources = finder.sources(Duration::ZERO)?;
 ///     for source in sources {
 ///         println!("Found: {}", source);
 ///     }
@@ -776,17 +777,18 @@ struct CachedSource {
 ///
 /// ```no_run
 /// use grafton_ndi::SourceCache;
+/// use std::time::Duration;
 ///
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// // Create a cache instance
 /// let cache = SourceCache::new()?;
 ///
 /// // Find a source by hostname or IP with automatic caching
-/// let source = cache.find_by_host("192.168.0.107", 5000)?;
+/// let source = cache.find_by_host("192.168.0.107", Duration::from_secs(5))?;
 /// println!("Found source: {}", source);
 ///
 /// // Subsequent lookups use the cache
-/// let same_source = cache.find_by_host("192.168.0.107", 5000)?;
+/// let same_source = cache.find_by_host("192.168.0.107", Duration::from_secs(5))?;
 ///
 /// # Ok(())
 /// # }
@@ -915,10 +917,11 @@ impl SourceCache {
     ///
     /// ```no_run
     /// use grafton_ndi::SourceCache;
+    /// use std::time::Duration;
     ///
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let cache = SourceCache::new()?;
-    /// let source = cache.find_by_host("192.168.0.107", 5000)?;
+    /// let source = cache.find_by_host("192.168.0.107", Duration::from_secs(5))?;
     ///
     /// // Later, if the source goes offline
     /// cache.invalidate("192.168.0.107");
@@ -941,11 +944,12 @@ impl SourceCache {
     ///
     /// ```no_run
     /// use grafton_ndi::SourceCache;
+    /// use std::time::Duration;
     ///
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let cache = SourceCache::new()?;
-    /// cache.find_by_host("192.168.0.107", 5000)?;
-    /// cache.find_by_host("192.168.0.108", 5000)?;
+    /// cache.find_by_host("192.168.0.107", Duration::from_secs(5))?;
+    /// cache.find_by_host("192.168.0.108", Duration::from_secs(5))?;
     ///
     /// // Clear all cached sources
     /// cache.clear();
@@ -965,12 +969,13 @@ impl SourceCache {
     ///
     /// ```no_run
     /// use grafton_ndi::SourceCache;
+    /// use std::time::Duration;
     ///
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let cache = SourceCache::new()?;
     /// assert_eq!(cache.len(), 0);
     ///
-    /// cache.find_by_host("192.168.0.107", 5000)?;
+    /// cache.find_by_host("192.168.0.107", Duration::from_secs(5))?;
     /// assert_eq!(cache.len(), 1);
     /// # Ok(())
     /// # }
@@ -986,12 +991,13 @@ impl SourceCache {
     ///
     /// ```no_run
     /// use grafton_ndi::SourceCache;
+    /// use std::time::Duration;
     ///
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let cache = SourceCache::new()?;
     /// assert!(cache.is_empty());
     ///
-    /// cache.find_by_host("192.168.0.107", 5000)?;
+    /// cache.find_by_host("192.168.0.107", Duration::from_secs(5))?;
     /// assert!(!cache.is_empty());
     /// # Ok(())
     /// # }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -16,20 +16,31 @@ use crate::{ndi_lib::*, Error, Result};
 /// These represent the various pixel formats supported by NDI for video frames.
 /// The most common formats are BGRA/RGBA for full quality and UYVY for bandwidth-efficient streaming.
 ///
+/// This enum is marked `#[non_exhaustive]` to allow future NDI SDK versions to add new formats
+/// without breaking existing code. Always use a wildcard pattern when matching.
+///
 /// # Examples
 ///
 /// ```
-/// use grafton_ndi::FourCCVideoType;
+/// use grafton_ndi::PixelFormat;
 ///
 /// // For maximum compatibility and quality
-/// let format = FourCCVideoType::BGRA;
+/// let format = PixelFormat::BGRA;
 ///
 /// // For bandwidth-efficient streaming
-/// let format = FourCCVideoType::UYVY;
+/// let format = PixelFormat::UYVY;
+///
+/// // When matching, always include a wildcard for forward compatibility
+/// match format {
+///     PixelFormat::BGRA | PixelFormat::RGBA => println!("Full quality RGB"),
+///     PixelFormat::UYVY => println!("Compressed YUV"),
+///     _ => println!("Other format"),
+/// }
 /// ```
 #[derive(Debug, TryFromPrimitive, IntoPrimitive, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 #[repr(u32)]
-pub enum FourCCVideoType {
+pub enum PixelFormat {
     /// YCbCr 4:2:2 format (16 bits per pixel) - bandwidth efficient.
     UYVY = NDIlib_FourCC_video_type_e_NDIlib_FourCC_video_type_UYVY as _,
     /// YCbCr 4:2:2 with alpha channel (24 bits per pixel).
@@ -52,28 +63,53 @@ pub enum FourCCVideoType {
     RGBA = NDIlib_FourCC_video_type_e_NDIlib_FourCC_video_type_RGBA as _,
     /// Red-Green-Blue with padding (32 bits per pixel).
     RGBX = NDIlib_FourCC_video_type_e_NDIlib_FourCC_video_type_RGBX as _,
-    Max = NDIlib_FourCC_video_type_e_NDIlib_FourCC_video_type_max as _,
 }
 
-impl From<FourCCVideoType> for i32 {
-    fn from(value: FourCCVideoType) -> Self {
+impl From<PixelFormat> for i32 {
+    fn from(value: PixelFormat) -> Self {
         let u32_value: u32 = value.into();
         u32_value as i32
     }
 }
 
-#[derive(Debug, TryFromPrimitive, IntoPrimitive, Clone, Copy)]
+/// Video scan type (progressive, interlaced, or field-based).
+///
+/// This enum describes how video frames are scanned/displayed.
+/// Most modern content uses Progressive, while legacy broadcast may use Interlaced or field-based formats.
+///
+/// This enum is marked `#[non_exhaustive]` to allow future NDI SDK versions to add new scan types
+/// without breaking existing code. Always use a wildcard pattern when matching.
+///
+/// # Examples
+///
+/// ```
+/// use grafton_ndi::ScanType;
+///
+/// let scan = ScanType::Progressive;
+///
+/// // When matching, always include a wildcard for forward compatibility
+/// match scan {
+///     ScanType::Progressive => println!("Progressive scan"),
+///     ScanType::Interlaced => println!("Interlaced"),
+///     _ => println!("Field-based or other"),
+/// }
+/// ```
+#[derive(Debug, TryFromPrimitive, IntoPrimitive, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 #[repr(u32)]
-pub enum FrameFormatType {
+pub enum ScanType {
+    /// Progressive scan - full frames rendered sequentially.
     Progressive = NDIlib_frame_format_type_e_NDIlib_frame_format_type_progressive as _,
+    /// Interlaced scan - alternating even/odd lines.
     Interlaced = NDIlib_frame_format_type_e_NDIlib_frame_format_type_interleaved as _,
+    /// Field 0 only (first field of interlaced content).
     Field0 = NDIlib_frame_format_type_e_NDIlib_frame_format_type_field_0 as _,
+    /// Field 1 only (second field of interlaced content).
     Field1 = NDIlib_frame_format_type_e_NDIlib_frame_format_type_field_1 as _,
-    Max = NDIlib_frame_format_type_e_NDIlib_frame_format_type_max as _,
 }
 
-impl From<FrameFormatType> for i32 {
-    fn from(value: FrameFormatType) -> Self {
+impl From<ScanType> for i32 {
+    fn from(value: ScanType) -> Self {
         let u32_value: u32 = value.into();
         u32_value as i32
     }
@@ -115,11 +151,11 @@ impl From<LineStrideOrSize> for NDIlib_video_frame_v2_t__bindgen_ty_1 {
 pub struct VideoFrame {
     pub width: i32,
     pub height: i32,
-    pub fourcc: FourCCVideoType,
+    pub pixel_format: PixelFormat,
     pub frame_rate_n: i32,
     pub frame_rate_d: i32,
     pub picture_aspect_ratio: f32,
-    pub frame_format_type: FrameFormatType,
+    pub scan_type: ScanType,
     pub timecode: i64,
     pub data: Vec<u8>,
     pub line_stride_or_size: LineStrideOrSize,
@@ -132,11 +168,11 @@ impl fmt::Debug for VideoFrame {
         f.debug_struct("VideoFrame")
             .field("width", &self.width)
             .field("height", &self.height)
-            .field("fourcc", &self.fourcc)
+            .field("pixel_format", &self.pixel_format)
             .field("frame_rate_n", &self.frame_rate_n)
             .field("frame_rate_d", &self.frame_rate_d)
             .field("picture_aspect_ratio", &self.picture_aspect_ratio)
-            .field("frame_format_type", &self.frame_format_type)
+            .field("scan_type", &self.scan_type)
             .field("timecode", &self.timecode)
             .field("data (bytes)", &self.data.len())
             .field("line_stride_or_size", &self.line_stride_or_size)
@@ -150,10 +186,10 @@ impl Default for VideoFrame {
     fn default() -> Self {
         VideoFrame::builder()
             .resolution(1920, 1080)
-            .fourcc(FourCCVideoType::BGRA)
+            .pixel_format(PixelFormat::BGRA)
             .frame_rate(60, 1)
             .aspect_ratio(16.0 / 9.0)
-            .format(FrameFormatType::Interlaced)
+            .scan_type(ScanType::Interlaced)
             .build()
             .expect("Default VideoFrame should always succeed")
     }
@@ -164,11 +200,11 @@ impl VideoFrame {
         NDIlib_video_frame_v2_t {
             xres: self.width,
             yres: self.height,
-            FourCC: self.fourcc.into(),
+            FourCC: self.pixel_format.into(),
             frame_rate_N: self.frame_rate_n,
             frame_rate_D: self.frame_rate_d,
             picture_aspect_ratio: self.picture_aspect_ratio,
-            frame_format_type: self.frame_format_type.into(),
+            frame_format_type: self.scan_type.into(),
             timecode: self.timecode,
             p_data: self.data.as_ptr() as *mut u8,
             __bindgen_anon_1: self.line_stride_or_size.into(),
@@ -227,13 +263,13 @@ impl VideoFrame {
         use png::{BitDepth, ColorType, Encoder};
 
         // Validate format
-        let bytes_per_pixel = match self.fourcc {
-            FourCCVideoType::RGBA | FourCCVideoType::RGBX => 4,
-            FourCCVideoType::BGRA | FourCCVideoType::BGRX => 4,
+        let bytes_per_pixel = match self.pixel_format {
+            PixelFormat::RGBA | PixelFormat::RGBX => 4,
+            PixelFormat::BGRA | PixelFormat::BGRX => 4,
             _ => {
-                let fourcc = self.fourcc;
+                let pixel_format = self.pixel_format;
                 return Err(Error::InvalidFrame(format!(
-                    "Unsupported format for PNG encoding: {fourcc:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
+                    "Unsupported format for PNG encoding: {pixel_format:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
                 )));
             }
         };
@@ -258,12 +294,12 @@ impl VideoFrame {
         }
 
         // Handle color format conversion if needed
-        let rgba_data: Vec<u8> = match self.fourcc {
-            FourCCVideoType::RGBA | FourCCVideoType::RGBX => {
+        let rgba_data: Vec<u8> = match self.pixel_format {
+            PixelFormat::RGBA | PixelFormat::RGBX => {
                 // Already in correct format, use as-is
                 self.data.to_vec()
             }
-            FourCCVideoType::BGRA | FourCCVideoType::BGRX => {
+            PixelFormat::BGRA | PixelFormat::BGRX => {
                 // Swap R and B channels (BGRA -> RGBA)
                 let mut rgba = self.data.to_vec();
                 for chunk in rgba.chunks_exact_mut(4) {
@@ -333,13 +369,13 @@ impl VideoFrame {
         use jpeg_encoder::{ColorType as JpegColorType, Encoder as JpegEncoder};
 
         // Validate format
-        let bytes_per_pixel = match self.fourcc {
-            FourCCVideoType::RGBA | FourCCVideoType::RGBX => 4,
-            FourCCVideoType::BGRA | FourCCVideoType::BGRX => 4,
+        let bytes_per_pixel = match self.pixel_format {
+            PixelFormat::RGBA | PixelFormat::RGBX => 4,
+            PixelFormat::BGRA | PixelFormat::BGRX => 4,
             _ => {
-                let fourcc = self.fourcc;
+                let pixel_format = self.pixel_format;
                 return Err(Error::InvalidFrame(format!(
-                    "Unsupported format for JPEG encoding: {fourcc:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
+                    "Unsupported format for JPEG encoding: {pixel_format:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
                 )));
             }
         };
@@ -364,15 +400,15 @@ impl VideoFrame {
         }
 
         // Convert to RGB (JPEG doesn't support alpha channel)
-        let rgb_data: Vec<u8> = match self.fourcc {
-            FourCCVideoType::RGBA | FourCCVideoType::RGBX => {
+        let rgb_data: Vec<u8> = match self.pixel_format {
+            PixelFormat::RGBA | PixelFormat::RGBX => {
                 // Strip alpha channel: RGBA -> RGB
                 self.data
                     .chunks_exact(4)
                     .flat_map(|chunk| [chunk[0], chunk[1], chunk[2]])
                     .collect()
             }
-            FourCCVideoType::BGRA | FourCCVideoType::BGRX => {
+            PixelFormat::BGRA | PixelFormat::BGRX => {
                 // Swap R/B and strip alpha: BGRA -> RGB
                 self.data
                     .chunks_exact(4)
@@ -457,14 +493,18 @@ impl VideoFrame {
         }
 
         #[allow(clippy::unnecessary_cast)] // Required for Windows where FourCC is i32
-        let fourcc =
-            FourCCVideoType::try_from(c_frame.FourCC as u32).unwrap_or(FourCCVideoType::Max);
+        let pixel_format = PixelFormat::try_from(c_frame.FourCC as u32).map_err(|_| {
+            Error::InvalidFrame(format!(
+                "Unknown pixel format FourCC: 0x{:08X}",
+                c_frame.FourCC
+            ))
+        })?;
 
         // Determine data size and LineStrideOrSize based on format.
         // The NDI SDK uses a union here: line_stride_in_bytes for uncompressed formats,
         // data_size_in_bytes for compressed formats.
         // We read ONLY the appropriate field based on the format to avoid UB.
-        let is_uncompressed = is_uncompressed_format(fourcc);
+        let is_uncompressed = is_uncompressed_format(pixel_format);
 
         let (data_size, line_stride_or_size) = if is_uncompressed {
             // Uncompressed format: read ONLY line_stride_in_bytes
@@ -518,16 +558,22 @@ impl VideoFrame {
             Some(CString::from(CStr::from_ptr(c_frame.p_metadata)))
         };
 
+        #[allow(clippy::unnecessary_cast)] // Required for Windows where frame_format_type is i32
+        let scan_type = ScanType::try_from(c_frame.frame_format_type as u32).map_err(|_| {
+            Error::InvalidFrame(format!(
+                "Unknown scan type: 0x{:08X}",
+                c_frame.frame_format_type
+            ))
+        })?;
+
         Ok(VideoFrame {
             width: c_frame.xres,
             height: c_frame.yres,
-            fourcc,
+            pixel_format,
             frame_rate_n: c_frame.frame_rate_N,
             frame_rate_d: c_frame.frame_rate_D,
             picture_aspect_ratio: c_frame.picture_aspect_ratio,
-            #[allow(clippy::unnecessary_cast)] // Required for Windows where frame_format_type is i32
-            frame_format_type: FrameFormatType::try_from(c_frame.frame_format_type as u32)
-                .unwrap_or(FrameFormatType::Max),
+            scan_type,
             timecode: c_frame.timecode,
             data,
             line_stride_or_size,
@@ -547,11 +593,11 @@ impl VideoFrame {
 pub struct VideoFrameBuilder {
     width: Option<i32>,
     height: Option<i32>,
-    fourcc: Option<FourCCVideoType>,
+    pixel_format: Option<PixelFormat>,
     frame_rate_n: Option<i32>,
     frame_rate_d: Option<i32>,
     picture_aspect_ratio: Option<f32>,
-    frame_format_type: Option<FrameFormatType>,
+    scan_type: Option<ScanType>,
     timecode: Option<i64>,
     metadata: Option<String>,
     timestamp: Option<i64>,
@@ -563,11 +609,11 @@ impl VideoFrameBuilder {
         Self {
             width: None,
             height: None,
-            fourcc: None,
+            pixel_format: None,
             frame_rate_n: None,
             frame_rate_d: None,
             picture_aspect_ratio: None,
-            frame_format_type: None,
+            scan_type: None,
             timecode: None,
             metadata: None,
             timestamp: None,
@@ -584,8 +630,8 @@ impl VideoFrameBuilder {
 
     /// Set the pixel format
     #[must_use]
-    pub fn fourcc(mut self, fourcc: FourCCVideoType) -> Self {
-        self.fourcc = Some(fourcc);
+    pub fn pixel_format(mut self, pixel_format: PixelFormat) -> Self {
+        self.pixel_format = Some(pixel_format);
         self
     }
 
@@ -604,10 +650,10 @@ impl VideoFrameBuilder {
         self
     }
 
-    /// Set the frame format type (progressive, interlaced, etc.)
+    /// Set the scan type (progressive, interlaced, etc.)
     #[must_use]
-    pub fn format(mut self, format: FrameFormatType) -> Self {
-        self.frame_format_type = Some(format);
+    pub fn scan_type(mut self, scan_type: ScanType) -> Self {
+        self.scan_type = Some(scan_type);
         self
     }
 
@@ -636,27 +682,25 @@ impl VideoFrameBuilder {
     pub fn build(self) -> Result<VideoFrame> {
         let width = self.width.unwrap_or(1920);
         let height = self.height.unwrap_or(1080);
-        let fourcc = self.fourcc.unwrap_or(FourCCVideoType::BGRA);
+        let pixel_format = self.pixel_format.unwrap_or(PixelFormat::BGRA);
         let frame_rate_n = self.frame_rate_n.unwrap_or(60);
         let frame_rate_d = self.frame_rate_d.unwrap_or(1);
         let picture_aspect_ratio = self.picture_aspect_ratio.unwrap_or(16.0 / 9.0);
-        let frame_format_type = self
-            .frame_format_type
-            .unwrap_or(FrameFormatType::Progressive);
+        let scan_type = self.scan_type.unwrap_or(ScanType::Progressive);
 
         // Calculate stride and buffer size
-        let stride = calculate_line_stride(fourcc, width);
-        let buffer_size = calculate_buffer_size(fourcc, width, height);
+        let stride = calculate_line_stride(pixel_format, width);
+        let buffer_size = calculate_buffer_size(pixel_format, width, height);
         let data = vec![0u8; buffer_size];
 
         let mut frame = VideoFrame {
             width,
             height,
-            fourcc,
+            pixel_format,
             frame_rate_n,
             frame_rate_d,
             picture_aspect_ratio,
-            frame_format_type,
+            scan_type,
             timecode: self.timecode.unwrap_or(0),
             data: (data),
             line_stride_or_size: LineStrideOrSize::LineStrideBytes(stride),
@@ -691,7 +735,7 @@ pub struct AudioFrame {
     pub num_channels: i32,
     pub num_samples: i32,
     pub timecode: i64,
-    pub fourcc: AudioType,
+    pub fourcc: AudioFormat,
     data: Vec<f32>,
     pub channel_stride_in_bytes: i32,
     pub metadata: Option<CString>,
@@ -762,15 +806,22 @@ impl AudioFrame {
             Some(unsafe { CString::from(CStr::from_ptr(raw.p_metadata)) })
         };
 
+        let fourcc = match raw.FourCC {
+            NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => AudioFormat::FLTP,
+            _ => {
+                return Err(Error::InvalidFrame(format!(
+                    "Unknown audio format FourCC: 0x{:08X}",
+                    raw.FourCC
+                )))
+            }
+        };
+
         Ok(AudioFrame {
             sample_rate: raw.sample_rate,
             num_channels: raw.no_channels,
             num_samples: raw.no_samples,
             timecode: raw.timecode,
-            fourcc: match raw.FourCC {
-                NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => AudioType::FLTP,
-                _ => AudioType::Max,
-            },
+            fourcc,
             data,
             channel_stride_in_bytes: unsafe { raw.__bindgen_anon_1.channel_stride_in_bytes },
             metadata,
@@ -829,7 +880,7 @@ pub struct AudioFrameBuilder {
     num_channels: Option<i32>,
     num_samples: Option<i32>,
     timecode: Option<i64>,
-    fourcc: Option<AudioType>,
+    fourcc: Option<AudioFormat>,
     data: Option<Vec<f32>>,
     layout: Option<AudioLayout>,
     metadata: Option<String>,
@@ -882,7 +933,7 @@ impl AudioFrameBuilder {
 
     /// Set the audio format
     #[must_use]
-    pub fn format(mut self, format: AudioType) -> Self {
+    pub fn format(mut self, format: AudioFormat) -> Self {
         self.fourcc = Some(format);
         self
     }
@@ -946,7 +997,7 @@ impl AudioFrameBuilder {
         let sample_rate = self.sample_rate.unwrap_or(48000);
         let num_channels = self.num_channels.unwrap_or(2);
         let num_samples = self.num_samples.unwrap_or(1024);
-        let fourcc = self.fourcc.unwrap_or(AudioType::FLTP);
+        let fourcc = self.fourcc.unwrap_or(AudioFormat::FLTP);
         let layout = self.layout.unwrap_or(AudioLayout::Planar);
 
         let data = if let Some(data) = self.data {
@@ -1005,11 +1056,32 @@ impl Drop for AudioFrame {
     }
 }
 
+/// Audio format identifiers (FourCC codes).
+///
+/// Currently NDI primarily uses `FLTP` (32-bit floating point planar format).
+///
+/// This enum is marked `#[non_exhaustive]` to allow future NDI SDK versions to add new audio formats
+/// without breaking existing code. Always use a wildcard pattern when matching.
+///
+/// # Examples
+///
+/// ```
+/// use grafton_ndi::AudioFormat;
+///
+/// let format = AudioFormat::FLTP;
+///
+/// // When matching, always include a wildcard for forward compatibility
+/// match format {
+///     AudioFormat::FLTP => println!("32-bit float planar"),
+///     _ => println!("Other format"),
+/// }
+/// ```
 #[derive(Debug, TryFromPrimitive, IntoPrimitive, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 #[repr(u32)]
-pub enum AudioType {
+pub enum AudioFormat {
+    /// 32-bit floating point planar audio (FLTP).
     FLTP = NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP as _,
-    Max = NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_max as _,
 }
 
 /// Audio data layout format
@@ -1034,63 +1106,57 @@ pub enum AudioLayout {
     Interleaved,
 }
 
-impl From<AudioType> for i32 {
-    fn from(value: AudioType) -> Self {
+impl From<AudioFormat> for i32 {
+    fn from(value: AudioFormat) -> Self {
         let u32_value: u32 = value.into();
         u32_value as i32
     }
 }
 
 /// Calculate the line stride (bytes per row) for a given video format
-pub(crate) fn calculate_line_stride(fourcc: FourCCVideoType, width: i32) -> i32 {
+pub(crate) fn calculate_line_stride(fourcc: PixelFormat, width: i32) -> i32 {
     match fourcc {
-        FourCCVideoType::BGRA
-        | FourCCVideoType::BGRX
-        | FourCCVideoType::RGBA
-        | FourCCVideoType::RGBX => width * 4, // 32 bpp = 4 bytes per pixel
-        FourCCVideoType::UYVY => width * 2, // 16 bpp = 2 bytes per pixel
-        FourCCVideoType::YV12 | FourCCVideoType::I420 | FourCCVideoType::NV12 => width, // Y plane stride for planar formats
-        FourCCVideoType::UYVA => width * 3, // 24 bpp = 3 bytes per pixel
-        FourCCVideoType::P216 | FourCCVideoType::PA16 => width * 4, // 32 bpp = 4 bytes per pixel
-        _ => width * 4,                     // Default to 32 bpp
+        PixelFormat::BGRA | PixelFormat::BGRX | PixelFormat::RGBA | PixelFormat::RGBX => width * 4, // 32 bpp = 4 bytes per pixel
+        PixelFormat::UYVY => width * 2, // 16 bpp = 2 bytes per pixel
+        PixelFormat::YV12 | PixelFormat::I420 | PixelFormat::NV12 => width, // Y plane stride for planar formats
+        PixelFormat::UYVA => width * 3, // 24 bpp = 3 bytes per pixel
+        PixelFormat::P216 | PixelFormat::PA16 => width * 4, // 32 bpp = 4 bytes per pixel
     }
 }
 
 /// Calculate the total buffer size needed for a video frame
-fn calculate_buffer_size(fourcc: FourCCVideoType, width: i32, height: i32) -> usize {
+fn calculate_buffer_size(fourcc: PixelFormat, width: i32, height: i32) -> usize {
     match fourcc {
-        FourCCVideoType::BGRA
-        | FourCCVideoType::BGRX
-        | FourCCVideoType::RGBA
-        | FourCCVideoType::RGBX => (height * width * 4) as usize, // 32 bpp
-        FourCCVideoType::UYVY => (height * width * 2) as usize, // 16 bpp
-        FourCCVideoType::YV12 | FourCCVideoType::I420 | FourCCVideoType::NV12 => {
+        PixelFormat::BGRA | PixelFormat::BGRX | PixelFormat::RGBA | PixelFormat::RGBX => {
+            (height * width * 4) as usize
+        } // 32 bpp
+        PixelFormat::UYVY => (height * width * 2) as usize, // 16 bpp
+        PixelFormat::YV12 | PixelFormat::I420 | PixelFormat::NV12 => {
             // Planar 4:2:0 formats: Y plane is full res, U/V planes are quarter size
             let y_size = (width * height) as usize;
             let uv_size = ((width / 2) * (height / 2)) as usize;
             y_size + 2 * uv_size
         }
-        FourCCVideoType::UYVA => (height * width * 3) as usize, // 24 bpp
-        FourCCVideoType::P216 | FourCCVideoType::PA16 => (height * width * 4) as usize, // 32 bpp
-        _ => (height * width * 4) as usize,                     // Default to 32 bpp
+        PixelFormat::UYVA => (height * width * 3) as usize, // 24 bpp
+        PixelFormat::P216 | PixelFormat::PA16 => (height * width * 4) as usize, // 32 bpp
     }
 }
 
 /// Check if a video format is uncompressed
-pub(crate) fn is_uncompressed_format(fourcc: FourCCVideoType) -> bool {
+pub(crate) fn is_uncompressed_format(fourcc: PixelFormat) -> bool {
     matches!(
         fourcc,
-        FourCCVideoType::BGRA
-            | FourCCVideoType::BGRX
-            | FourCCVideoType::RGBA
-            | FourCCVideoType::RGBX
-            | FourCCVideoType::UYVY
-            | FourCCVideoType::UYVA
-            | FourCCVideoType::YV12
-            | FourCCVideoType::I420
-            | FourCCVideoType::NV12
-            | FourCCVideoType::P216
-            | FourCCVideoType::PA16
+        PixelFormat::BGRA
+            | PixelFormat::BGRX
+            | PixelFormat::RGBA
+            | PixelFormat::RGBX
+            | PixelFormat::UYVY
+            | PixelFormat::UYVA
+            | PixelFormat::YV12
+            | PixelFormat::I420
+            | PixelFormat::NV12
+            | PixelFormat::P216
+            | PixelFormat::PA16
     )
 }
 
@@ -1261,9 +1327,11 @@ impl VideoFrameRef {
     }
 
     /// Get the pixel format (FourCC code).
-    pub fn fourcc(&self) -> FourCCVideoType {
+    ///
+    /// Returns `PixelFormat::BGRA` as a fallback if the SDK returns an unknown format code.
+    pub fn pixel_format(&self) -> PixelFormat {
         #[allow(clippy::unnecessary_cast)]
-        FourCCVideoType::try_from(self.guard.frame().FourCC as u32).unwrap_or(FourCCVideoType::Max)
+        PixelFormat::try_from(self.guard.frame().FourCC as u32).unwrap_or(PixelFormat::BGRA)
     }
 
     /// Get the frame rate numerator.
@@ -1281,11 +1349,13 @@ impl VideoFrameRef {
         self.guard.frame().picture_aspect_ratio
     }
 
-    /// Get the frame format type (progressive, interlaced, etc.).
-    pub fn frame_format_type(&self) -> FrameFormatType {
+    /// Get the scan type (progressive, interlaced, etc.).
+    ///
+    /// Returns `ScanType::Progressive` as a fallback if the SDK returns an unknown scan type code.
+    pub fn scan_type(&self) -> ScanType {
         #[allow(clippy::unnecessary_cast)]
-        FrameFormatType::try_from(self.guard.frame().frame_format_type as u32)
-            .unwrap_or(FrameFormatType::Max)
+        ScanType::try_from(self.guard.frame().frame_format_type as u32)
+            .unwrap_or(ScanType::Progressive)
     }
 
     /// Get the timecode.
@@ -1300,8 +1370,8 @@ impl VideoFrameRef {
 
     /// Get the line stride or data size.
     pub fn line_stride_or_size(&self) -> LineStrideOrSize {
-        let fourcc = self.fourcc();
-        let is_uncompressed = is_uncompressed_format(fourcc);
+        let pixel_format = self.pixel_format();
+        let is_uncompressed = is_uncompressed_format(pixel_format);
 
         if is_uncompressed {
             let line_stride = unsafe { self.guard.frame().__bindgen_anon_1.line_stride_in_bytes };
@@ -1333,8 +1403,8 @@ impl VideoFrameRef {
             return &[];
         }
 
-        let fourcc = self.fourcc();
-        let is_uncompressed = is_uncompressed_format(fourcc);
+        let pixel_format = self.pixel_format();
+        let is_uncompressed = is_uncompressed_format(pixel_format);
 
         let data_size = if is_uncompressed {
             let line_stride = unsafe { frame.__bindgen_anon_1.line_stride_in_bytes };
@@ -1373,11 +1443,11 @@ impl fmt::Debug for VideoFrameRef {
         f.debug_struct("VideoFrameRef")
             .field("width", &self.width())
             .field("height", &self.height())
-            .field("fourcc", &self.fourcc())
+            .field("pixel_format", &self.pixel_format())
             .field("frame_rate_n", &self.frame_rate_n())
             .field("frame_rate_d", &self.frame_rate_d())
             .field("picture_aspect_ratio", &self.picture_aspect_ratio())
-            .field("frame_format_type", &self.frame_format_type())
+            .field("scan_type", &self.scan_type())
             .field("timecode", &self.timecode())
             .field("data (bytes)", &self.data().len())
             .field("line_stride_or_size", &self.line_stride_or_size())
@@ -1460,10 +1530,12 @@ impl AudioFrameRef {
     }
 
     /// Get the audio format (FourCC code).
-    pub fn fourcc(&self) -> AudioType {
+    ///
+    /// Returns `AudioFormat::FLTP` as a fallback if the SDK returns an unknown format code.
+    pub fn format(&self) -> AudioFormat {
         match self.guard.frame().FourCC {
-            NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => AudioType::FLTP,
-            _ => AudioType::Max,
+            NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => AudioFormat::FLTP,
+            _ => AudioFormat::FLTP,
         }
     }
 
@@ -1517,7 +1589,7 @@ impl fmt::Debug for AudioFrameRef {
             .field("num_channels", &self.num_channels())
             .field("num_samples", &self.num_samples())
             .field("timecode", &self.timecode())
-            .field("fourcc", &self.fourcc())
+            .field("format", &self.format())
             .field("data (samples)", &self.data().len())
             .field("channel_stride_in_bytes", &self.channel_stride_in_bytes())
             .field("metadata", &self.metadata())

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -735,7 +735,7 @@ pub struct AudioFrame {
     pub num_channels: i32,
     pub num_samples: i32,
     pub timecode: i64,
-    pub fourcc: AudioFormat,
+    pub format: AudioFormat,
     data: Vec<f32>,
     pub channel_stride_in_bytes: i32,
     pub metadata: Option<CString>,
@@ -749,7 +749,7 @@ impl AudioFrame {
             no_channels: self.num_channels,
             no_samples: self.num_samples,
             timecode: self.timecode,
-            FourCC: self.fourcc.into(),
+            FourCC: self.format.into(),
             p_data: self.data.as_ptr() as *mut f32 as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
                 channel_stride_in_bytes: self.channel_stride_in_bytes,
@@ -806,7 +806,7 @@ impl AudioFrame {
             Some(unsafe { CString::from(CStr::from_ptr(raw.p_metadata)) })
         };
 
-        let fourcc = match raw.FourCC {
+        let format = match raw.FourCC {
             NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => AudioFormat::FLTP,
             _ => {
                 return Err(Error::InvalidFrame(format!(
@@ -821,7 +821,7 @@ impl AudioFrame {
             num_channels: raw.no_channels,
             num_samples: raw.no_samples,
             timecode: raw.timecode,
-            fourcc,
+            format,
             data,
             channel_stride_in_bytes: unsafe { raw.__bindgen_anon_1.channel_stride_in_bytes },
             metadata,
@@ -880,7 +880,7 @@ pub struct AudioFrameBuilder {
     num_channels: Option<i32>,
     num_samples: Option<i32>,
     timecode: Option<i64>,
-    fourcc: Option<AudioFormat>,
+    format: Option<AudioFormat>,
     data: Option<Vec<f32>>,
     layout: Option<AudioLayout>,
     metadata: Option<String>,
@@ -895,7 +895,7 @@ impl AudioFrameBuilder {
             num_channels: None,
             num_samples: None,
             timecode: None,
-            fourcc: None,
+            format: None,
             data: None,
             layout: None,
             metadata: None,
@@ -934,7 +934,7 @@ impl AudioFrameBuilder {
     /// Set the audio format
     #[must_use]
     pub fn format(mut self, format: AudioFormat) -> Self {
-        self.fourcc = Some(format);
+        self.format = Some(format);
         self
     }
 
@@ -997,7 +997,7 @@ impl AudioFrameBuilder {
         let sample_rate = self.sample_rate.unwrap_or(48000);
         let num_channels = self.num_channels.unwrap_or(2);
         let num_samples = self.num_samples.unwrap_or(1024);
-        let fourcc = self.fourcc.unwrap_or(AudioFormat::FLTP);
+        let format = self.format.unwrap_or(AudioFormat::FLTP);
         let layout = self.layout.unwrap_or(AudioLayout::Planar);
 
         let data = if let Some(data) = self.data {
@@ -1026,7 +1026,7 @@ impl AudioFrameBuilder {
             num_channels,
             num_samples,
             timecode: self.timecode.unwrap_or(0),
-            fourcc,
+            format,
             data,
             channel_stride_in_bytes,
             metadata: metadata_cstring,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -243,16 +243,18 @@ impl VideoFrame {
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, ReceiverColorFormat};
+    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, Receiver, ReceiverColorFormat};
+    /// # use std::time::Duration;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
-    /// # finder.wait_for_sources(1000);
-    /// # let sources = finder.get_sources(0)?;
-    /// # let receiver = ReceiverOptions::builder(sources[0].clone())
+    /// # finder.wait_for_sources(Duration::from_millis(1000))?;
+    /// # let sources = finder.sources(Duration::ZERO)?;
+    /// # let options = ReceiverOptions::builder(sources[0].clone())
     /// #     .color(ReceiverColorFormat::RGBX_RGBA)
-    /// #     .build(&ndi)?;
-    /// let video_frame = receiver.capture_video_blocking(5000)?;
+    /// #     .build();
+    /// # let receiver = Receiver::new(&ndi, &options)?;
+    /// let video_frame = receiver.capture_video(Duration::from_secs(5))?;
     /// let png_bytes = video_frame.encode_png()?;
     /// std::fs::write("frame.png", &png_bytes)?;
     /// # Ok(())
@@ -349,16 +351,18 @@ impl VideoFrame {
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, ReceiverColorFormat};
+    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, Receiver, ReceiverColorFormat};
+    /// # use std::time::Duration;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
-    /// # finder.wait_for_sources(1000);
-    /// # let sources = finder.get_sources(0)?;
-    /// # let receiver = ReceiverOptions::builder(sources[0].clone())
+    /// # finder.wait_for_sources(Duration::from_millis(1000))?;
+    /// # let sources = finder.sources(Duration::ZERO)?;
+    /// # let options = ReceiverOptions::builder(sources[0].clone())
     /// #     .color(ReceiverColorFormat::RGBX_RGBA)
-    /// #     .build(&ndi)?;
-    /// let video_frame = receiver.capture_video_blocking(5000)?;
+    /// #     .build();
+    /// # let receiver = Receiver::new(&ndi, &options)?;
+    /// let video_frame = receiver.capture_video(Duration::from_secs(5))?;
     /// let jpeg_bytes = video_frame.encode_jpeg(85)?;
     /// std::fs::write("frame.jpg", &jpeg_bytes)?;
     /// # Ok(())
@@ -446,16 +450,18 @@ impl VideoFrame {
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, ReceiverColorFormat, ImageFormat};
+    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, Receiver, ReceiverColorFormat, ImageFormat};
+    /// # use std::time::Duration;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
-    /// # finder.wait_for_sources(1000);
-    /// # let sources = finder.get_sources(0)?;
-    /// # let receiver = ReceiverOptions::builder(sources[0].clone())
+    /// # finder.wait_for_sources(Duration::from_millis(1000))?;
+    /// # let sources = finder.sources(Duration::ZERO)?;
+    /// # let options = ReceiverOptions::builder(sources[0].clone())
     /// #     .color(ReceiverColorFormat::RGBX_RGBA)
-    /// #     .build(&ndi)?;
-    /// let video_frame = receiver.capture_video_blocking(5000)?;
+    /// #     .build();
+    /// # let receiver = Receiver::new(&ndi, &options)?;
+    /// let video_frame = receiver.capture_video(Duration::from_secs(5))?;
     ///
     /// // As PNG
     /// let data_url = video_frame.encode_data_url(ImageFormat::Png)?;
@@ -1267,13 +1273,15 @@ use crate::recv_guard::{RecvAudioGuard, RecvMetadataGuard, RecvVideoGuard};
 /// # Examples
 ///
 /// ```no_run
-/// # use grafton_ndi::{NDI, ReceiverOptions, Source, SourceAddress};
+/// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, Source, SourceAddress};
+/// # use std::time::Duration;
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// # let ndi = NDI::new()?;
 /// # let source = Source { name: "Test".into(), address: SourceAddress::None };
-/// # let receiver = ReceiverOptions::builder(source).build(&ndi)?;
+/// # let options = ReceiverOptions::builder(source).build();
+/// # let receiver = Receiver::new(&ndi, &options)?;
 /// // Zero-copy capture (no allocation, no memcpy)
-/// if let Some(frame) = receiver.capture_video_ref(1000)? {
+/// if let Some(frame) = receiver.capture_video_ref(Duration::from_millis(1000))? {
 ///     println!("{}×{} frame, {} bytes", frame.width(), frame.height(), frame.data().len());
 ///
 ///     // Process in place - no copy needed
@@ -1288,12 +1296,14 @@ use crate::recv_guard::{RecvAudioGuard, RecvMetadataGuard, RecvVideoGuard};
 /// To convert to an owned frame:
 ///
 /// ```no_run
-/// # use grafton_ndi::{NDI, ReceiverOptions, Source, SourceAddress};
+/// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, Source, SourceAddress};
+/// # use std::time::Duration;
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// # let ndi = NDI::new()?;
 /// # let source = Source { name: "Test".into(), address: SourceAddress::None };
-/// # let receiver = ReceiverOptions::builder(source).build(&ndi)?;
-/// if let Some(frame_ref) = receiver.capture_video_ref(1000)? {
+/// # let options = ReceiverOptions::builder(source).build();
+/// # let receiver = Receiver::new(&ndi, &options)?;
+/// if let Some(frame_ref) = receiver.capture_video_ref(Duration::from_millis(1000))? {
 ///     // Convert to owned for storage or cross-thread use
 ///     let owned = frame_ref.to_owned()?;
 ///     // owned is now a VideoFrame that can be sent across threads
@@ -1472,13 +1482,15 @@ impl fmt::Debug for VideoFrameRef {
 /// # Examples
 ///
 /// ```no_run
-/// # use grafton_ndi::{NDI, ReceiverOptions, Source, SourceAddress};
+/// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, Source, SourceAddress};
+/// # use std::time::Duration;
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// # let ndi = NDI::new()?;
 /// # let source = Source { name: "Test".into(), address: SourceAddress::None };
-/// # let receiver = ReceiverOptions::builder(source).build(&ndi)?;
+/// # let options = ReceiverOptions::builder(source).build();
+/// # let receiver = Receiver::new(&ndi, &options)?;
 /// // Zero-copy capture
-/// if let Some(frame) = receiver.capture_audio_ref(1000)? {
+/// if let Some(frame) = receiver.capture_audio_ref(Duration::from_millis(1000))? {
 ///     println!("{} channels, {} samples", frame.num_channels(), frame.num_samples());
 ///
 ///     // Process in place - no copy needed
@@ -1613,13 +1625,15 @@ impl fmt::Debug for AudioFrameRef {
 /// # Examples
 ///
 /// ```no_run
-/// # use grafton_ndi::{NDI, ReceiverOptions, Source, SourceAddress};
+/// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, Source, SourceAddress};
+/// # use std::time::Duration;
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// # let ndi = NDI::new()?;
 /// # let source = Source { name: "Test".into(), address: SourceAddress::None };
-/// # let receiver = ReceiverOptions::builder(source).build(&ndi)?;
+/// # let options = ReceiverOptions::builder(source).build();
+/// # let receiver = Receiver::new(&ndi, &options)?;
 /// // Zero-copy capture
-/// if let Some(frame) = receiver.capture_metadata_ref(1000)? {
+/// if let Some(frame) = receiver.capture_metadata_ref(Duration::from_millis(1000))? {
 ///     println!("Metadata: {}", frame.data().to_string_lossy());
 ///
 ///     // Frame is freed here when `frame` goes out of scope

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,14 +63,14 @@
 //! The completion callback notifies when the buffer can be reused:
 //!
 //! ```no_run
-//! # use grafton_ndi::{NDI, SenderOptions, BorrowedVideoFrame, FourCCVideoType};
+//! # use grafton_ndi::{NDI, SenderOptions, BorrowedVideoFrame, PixelFormat};
 //! # let ndi = NDI::new().unwrap();
 //! # let mut sender = grafton_ndi::Sender::new(&ndi, &SenderOptions::builder("Test").build().unwrap()).unwrap();
 //! // Register callback to know when buffer is released
 //! sender.on_async_video_done(|len| println!("Buffer released: {} bytes", len));
 //!
 //! let buffer = vec![0u8; 1920 * 1080 * 4];
-//! let frame = BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, FourCCVideoType::BGRA, 30, 1);
+//! let frame = BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
 //! let token = sender.send_video_async(&frame);
 //! // Buffer is now owned by NDI - cannot be modified until callback fires
 //! // The AsyncVideoToken must be kept alive to track the operation
@@ -120,9 +120,9 @@ pub use {
     error::*,
     finder::{Finder, FinderOptions, FinderOptionsBuilder, Source, SourceAddress, SourceCache},
     frames::{
-        AudioFrame, AudioFrameBuilder, AudioFrameRef, AudioLayout, AudioType, FourCCVideoType,
-        FrameFormatType, LineStrideOrSize, MetadataFrame, MetadataFrameRef, VideoFrame,
-        VideoFrameBuilder, VideoFrameRef,
+        AudioFormat, AudioFrame, AudioFrameBuilder, AudioFrameRef, AudioLayout, LineStrideOrSize,
+        MetadataFrame, MetadataFrameRef, PixelFormat, ScanType, VideoFrame, VideoFrameBuilder,
+        VideoFrameRef,
     },
     receiver::{
         ConnectionStats, FrameType, Receiver, ReceiverBandwidth, ReceiverColorFormat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 //! ```no_run
 //! use grafton_ndi::{NDI, FinderOptions, Finder};
+//! use std::time::Duration;
 //!
 //! # fn main() -> Result<(), grafton_ndi::Error> {
 //! // Initialize the NDI runtime
@@ -18,8 +19,7 @@
 //! let finder = Finder::new(&ndi, &options)?;
 //!
 //! // Discover sources
-//! finder.wait_for_sources(5000);
-//! let sources = finder.get_sources(0)?;
+//! let sources = finder.find_sources(Duration::from_secs(5))?;
 //!
 //! for source in sources {
 //!     println!("Found: {}", source);
@@ -65,7 +65,7 @@
 //! ```no_run
 //! # use grafton_ndi::{NDI, SenderOptions, BorrowedVideoFrame, PixelFormat};
 //! # let ndi = NDI::new().unwrap();
-//! # let mut sender = grafton_ndi::Sender::new(&ndi, &SenderOptions::builder("Test").build().unwrap()).unwrap();
+//! # let mut sender = grafton_ndi::Sender::new(&ndi, &SenderOptions::builder("Test").build()).unwrap();
 //! // Register callback to know when buffer is released
 //! sender.on_async_video_done(|len| println!("Buffer released: {} bytes", len));
 //!

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -225,15 +225,16 @@ impl ReceiverOptionsBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptionsBuilder};
+    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptionsBuilder, Receiver};
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
-    /// # finder.wait_for_sources(1000);
-    /// # let sources = finder.get_sources(0)?;
-    /// let receiver = ReceiverOptionsBuilder::snapshot_preset(sources[0].clone())
+    /// # finder.wait_for_sources(Duration::from_secs(1));
+    /// # let sources = finder.sources(Duration::ZERO)?;
+    /// let options = ReceiverOptionsBuilder::snapshot_preset(sources[0].clone())
     ///     .name("Snapshot Receiver")
-    ///     .build(&ndi)?;
+    ///     .build();
+    /// let receiver = Receiver::new(&ndi, &options)?;
     ///
     /// // Capture and encode in one line (requires image-encoding feature)
     /// #[cfg(feature = "image-encoding")]
@@ -268,15 +269,16 @@ impl ReceiverOptionsBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptionsBuilder};
+    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptionsBuilder, Receiver};
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
-    /// # finder.wait_for_sources(1000);
-    /// # let sources = finder.get_sources(0)?;
-    /// let receiver = ReceiverOptionsBuilder::high_quality_preset(sources[0].clone())
+    /// # finder.wait_for_sources(Duration::from_secs(1));
+    /// # let sources = finder.sources(Duration::ZERO)?;
+    /// let options = ReceiverOptionsBuilder::high_quality_preset(sources[0].clone())
     ///     .name("High Quality Receiver")
-    ///     .build(&ndi)?;
+    ///     .build();
+    /// let receiver = Receiver::new(&ndi, &options)?;
     ///
     /// // Capture full quality frames
     /// let frame = receiver.capture_video_blocking(5000)?;
@@ -307,15 +309,17 @@ impl ReceiverOptionsBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptionsBuilder};
+    /// # use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptionsBuilder, Receiver};
+    /// # use std::time::Duration;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let finder = Finder::new(&ndi, &FinderOptions::default())?;
-    /// # finder.wait_for_sources(1000);
-    /// # let sources = finder.get_sources(0)?;
-    /// let receiver = ReceiverOptionsBuilder::monitoring_preset(sources[0].clone())
+    /// # finder.wait_for_sources(Duration::from_secs(1));
+    /// # let sources = finder.sources(Duration::ZERO)?;
+    /// let options = ReceiverOptionsBuilder::monitoring_preset(sources[0].clone())
     ///     .name("Tally Monitor")
-    ///     .build(&ndi)?;
+    ///     .build();
+    /// let receiver = Receiver::new(&ndi, &options)?;
     ///
     /// // Poll for status changes
     /// if let Some(status) = receiver.poll_status_change(1000) {
@@ -364,16 +368,31 @@ impl ReceiverOptionsBuilder {
         self
     }
 
-    /// Build the receiver and create a Receiver instance
-    pub fn build(self, ndi: &NDI) -> Result<Receiver> {
-        let receiver = ReceiverOptions {
+    /// Build the receiver options
+    ///
+    /// This method is infallible and simply applies defaults for any unset options.
+    /// To create a `Receiver`, pass the resulting `ReceiverOptions` to `Receiver::new()`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, Source};
+    /// # fn main() -> Result<(), grafton_ndi::Error> {
+    /// # let ndi = NDI::new()?;
+    /// # let source = Source::default();
+    /// let options = ReceiverOptions::builder(source).build();
+    /// let receiver = Receiver::new(&ndi, &options)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn build(self) -> ReceiverOptions {
+        ReceiverOptions {
             source_to_connect_to: self.source_to_connect_to,
             color_format: self.color_format.unwrap_or(ReceiverColorFormat::BGRX_BGRA),
             bandwidth: self.bandwidth.unwrap_or(ReceiverBandwidth::Highest),
             allow_video_fields: self.allow_video_fields.unwrap_or(true),
             ndi_recv_name: self.ndi_recv_name,
-        };
-        Receiver::new(ndi, &receiver)
+        }
     }
 }
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -356,15 +356,16 @@ impl<'a, 'buf> AsyncVideoToken<'a, 'buf> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, SenderOptions, PixelFormat};
+    /// # use grafton_ndi::{NDI, SenderOptions, PixelFormat, BorrowedVideoFrame};
     /// # use std::time::Duration;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let ndi = NDI::new()?;
     /// let options = SenderOptions::builder("Test Sender").build();
-    /// let sender = grafton_ndi::Sender::new(&ndi, &options)?;
+    /// let mut sender = grafton_ndi::Sender::new(&ndi, &options)?;
     ///
     /// let mut buffer = vec![0u8; 1920 * 1080 * 4];
-    /// let token = sender.send_video_async(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1)?;
+    /// let borrowed_frame = BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
+    /// let token = sender.send_video_async(&borrowed_frame);
     ///
     /// // Explicitly wait for completion instead of relying on Drop
     /// token.wait()?;
@@ -395,14 +396,15 @@ impl<'a, 'buf> AsyncVideoToken<'a, 'buf> {
     /// ```no_run
     /// # #[cfg(feature = "advanced_sdk")]
     /// # {
-    /// # use grafton_ndi::{NDI, SenderOptions, PixelFormat};
+    /// # use grafton_ndi::{NDI, SenderOptions, PixelFormat, BorrowedVideoFrame};
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let ndi = NDI::new()?;
     /// let options = SenderOptions::builder("Test Sender").build();
-    /// let sender = grafton_ndi::Sender::new(&ndi, &options)?;
+    /// let mut sender = grafton_ndi::Sender::new(&ndi, &options)?;
     ///
-    /// let buffer = vec![0u8; 1920 * 1080 * 4];
-    /// let token = sender.send_video_async(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1)?;
+    /// let mut buffer = vec![0u8; 1920 * 1080 * 4];
+    /// let borrowed_frame = BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
+    /// let token = sender.send_video_async(&borrowed_frame);
     ///
     /// // Poll for completion
     /// while !token.is_complete() {
@@ -602,14 +604,14 @@ impl<'a> Sender<'a> {
     /// let send_options = SenderOptions::builder("MyCam")
     ///     .clock_video(true)
     ///     .clock_audio(true)
-    ///     .build()?;
+    ///     .build();
     /// let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
     ///
     /// // Register callback to know when buffer is released
     /// sender.on_async_video_done(|len| println!("Buffer released: {len} bytes"));
     ///
     /// // Use borrowed buffer directly (zero-copy, no allocation)
-    /// let buffer = vec![0u8; 1920 * 1080 * 4];
+    /// let mut buffer = vec![0u8; 1920 * 1080 * 4];
     /// let borrowed_frame = BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
     /// let token = sender.send_video_async(&borrowed_frame);
     ///
@@ -657,7 +659,8 @@ impl<'a> Sender<'a> {
     /// # use grafton_ndi::{NDI, SenderOptions, AudioFrame};
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
-    /// # let sender = grafton_ndi::Sender::new(&ndi, &SenderOptions::builder("Test").build()?)?;
+    /// # let options = SenderOptions::builder("Test").build();
+    /// # let sender = grafton_ndi::Sender::new(&ndi, &options)?;
     /// let mut audio_buffer = vec![0.0f32; 48000 * 2]; // 1 second of stereo audio
     ///
     /// // Fill buffer with audio data...
@@ -874,7 +877,8 @@ impl<'a> Sender<'a> {
     /// # use grafton_ndi::{NDI, SenderOptions, BorrowedVideoFrame, PixelFormat};
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let ndi = NDI::new()?;
-    /// let mut sender = grafton_ndi::Sender::new(&ndi, &SenderOptions::builder("Test").build()?)?;
+    /// let options = SenderOptions::builder("Test").build();
+    /// let mut sender = grafton_ndi::Sender::new(&ndi, &options)?;
     ///
     /// let mut buffer = vec![0u8; 1920 * 1080 * 4];
     /// let frame = BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
@@ -943,7 +947,8 @@ impl<'a> Sender<'a> {
     /// # use std::time::Duration;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// let ndi = NDI::new()?;
-    /// let sender = grafton_ndi::Sender::new(&ndi, &SenderOptions::builder("Test").build()?)?;
+    /// let options = SenderOptions::builder("Test").build();
+    /// let sender = grafton_ndi::Sender::new(&ndi, &options)?;
     ///
     /// // ... send some async frames ...
     ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -501,7 +501,7 @@ fn test_source_cache_invalidation() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_png_rgba() {
-    use crate::frames::{FourCCVideoType, VideoFrame};
+    use crate::frames::{PixelFormat, VideoFrame};
 
     let width = 2;
     let height = 2;
@@ -514,7 +514,7 @@ fn test_video_frame_encode_png_rgba() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::RGBA)
+        .pixel_format(PixelFormat::RGBA)
         .build()
         .unwrap();
 
@@ -533,7 +533,7 @@ fn test_video_frame_encode_png_rgba() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_png_bgra() {
-    use crate::frames::{FourCCVideoType, VideoFrame};
+    use crate::frames::{PixelFormat, VideoFrame};
 
     let width = 2;
     let height = 2;
@@ -546,7 +546,7 @@ fn test_video_frame_encode_png_bgra() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::BGRA)
+        .pixel_format(PixelFormat::BGRA)
         .build()
         .unwrap();
 
@@ -565,11 +565,11 @@ fn test_video_frame_encode_png_bgra() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_png_unsupported_format() {
-    use crate::frames::{FourCCVideoType, VideoFrame};
+    use crate::frames::{PixelFormat, VideoFrame};
 
     let frame = VideoFrame::builder()
         .resolution(2, 2)
-        .fourcc(FourCCVideoType::UYVY)
+        .pixel_format(PixelFormat::UYVY)
         .build()
         .unwrap();
 
@@ -584,7 +584,7 @@ fn test_video_frame_encode_png_unsupported_format() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_jpeg_rgba() {
-    use crate::frames::{FourCCVideoType, VideoFrame};
+    use crate::frames::{PixelFormat, VideoFrame};
 
     let width = 4;
     let height = 4;
@@ -592,7 +592,7 @@ fn test_video_frame_encode_jpeg_rgba() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::RGBA)
+        .pixel_format(PixelFormat::RGBA)
         .build()
         .unwrap();
 
@@ -614,7 +614,7 @@ fn test_video_frame_encode_jpeg_rgba() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_jpeg_bgra() {
-    use crate::frames::{FourCCVideoType, VideoFrame};
+    use crate::frames::{PixelFormat, VideoFrame};
 
     let width = 4;
     let height = 4;
@@ -622,7 +622,7 @@ fn test_video_frame_encode_jpeg_bgra() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::BGRA)
+        .pixel_format(PixelFormat::BGRA)
         .build()
         .unwrap();
 
@@ -641,7 +641,7 @@ fn test_video_frame_encode_jpeg_bgra() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_jpeg_quality_range() {
-    use crate::frames::{FourCCVideoType, VideoFrame};
+    use crate::frames::{PixelFormat, VideoFrame};
 
     // Create a more complex image with varying colors to better show compression differences
     let width = 32;
@@ -661,7 +661,7 @@ fn test_video_frame_encode_jpeg_quality_range() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::RGBA)
+        .pixel_format(PixelFormat::RGBA)
         .build()
         .unwrap();
 
@@ -683,7 +683,7 @@ fn test_video_frame_encode_jpeg_quality_range() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_data_url_png() {
-    use crate::frames::{FourCCVideoType, ImageFormat, VideoFrame};
+    use crate::frames::{ImageFormat, PixelFormat, VideoFrame};
 
     let width = 2;
     let height = 2;
@@ -691,7 +691,7 @@ fn test_video_frame_encode_data_url_png() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::RGBA)
+        .pixel_format(PixelFormat::RGBA)
         .build()
         .unwrap();
 
@@ -719,7 +719,7 @@ fn test_video_frame_encode_data_url_png() {
 #[cfg(feature = "image-encoding")]
 #[test]
 fn test_video_frame_encode_data_url_jpeg() {
-    use crate::frames::{FourCCVideoType, ImageFormat, VideoFrame};
+    use crate::frames::{ImageFormat, PixelFormat, VideoFrame};
 
     let width = 4;
     let height = 4;
@@ -727,7 +727,7 @@ fn test_video_frame_encode_data_url_jpeg() {
 
     let frame = VideoFrame::builder()
         .resolution(width, height)
-        .fourcc(FourCCVideoType::RGBA)
+        .pixel_format(PixelFormat::RGBA)
         .build()
         .unwrap();
 
@@ -943,33 +943,24 @@ fn test_tokio_async_receiver_methods_exist() {
 
             // All these methods should exist and be callable
             let _ = async_receiver
-                .capture_video(std::time::Duration::from_millis(100))
+                .capture_video(std::time::Duration::from_secs(5))
                 .await;
             let _ = async_receiver
-                .capture_video_with_retry(std::time::Duration::from_millis(100), 10)
-                .await;
-            let _ = async_receiver
-                .capture_video_blocking(std::time::Duration::from_secs(5))
+                .capture_video_timeout(std::time::Duration::from_millis(100))
                 .await;
 
             let _ = async_receiver
-                .capture_audio(std::time::Duration::from_millis(100))
+                .capture_audio(std::time::Duration::from_secs(5))
                 .await;
             let _ = async_receiver
-                .capture_audio_with_retry(std::time::Duration::from_millis(100), 10)
-                .await;
-            let _ = async_receiver
-                .capture_audio_blocking(std::time::Duration::from_secs(5))
+                .capture_audio_timeout(std::time::Duration::from_millis(100))
                 .await;
 
             let _ = async_receiver
-                .capture_metadata(std::time::Duration::from_millis(100))
+                .capture_metadata(std::time::Duration::from_secs(5))
                 .await;
             let _ = async_receiver
-                .capture_metadata_with_retry(std::time::Duration::from_millis(100), 10)
-                .await;
-            let _ = async_receiver
-                .capture_metadata_blocking(std::time::Duration::from_secs(5))
+                .capture_metadata_timeout(std::time::Duration::from_millis(100))
                 .await;
         }
     };
@@ -1034,33 +1025,24 @@ fn test_async_std_async_receiver_methods_exist() {
 
             // All these methods should exist and be callable
             let _ = async_receiver
-                .capture_video(std::time::Duration::from_millis(100))
+                .capture_video(std::time::Duration::from_secs(5))
                 .await;
             let _ = async_receiver
-                .capture_video_with_retry(std::time::Duration::from_millis(100), 10)
-                .await;
-            let _ = async_receiver
-                .capture_video_blocking(std::time::Duration::from_secs(5))
+                .capture_video_timeout(std::time::Duration::from_millis(100))
                 .await;
 
             let _ = async_receiver
-                .capture_audio(std::time::Duration::from_millis(100))
+                .capture_audio(std::time::Duration::from_secs(5))
                 .await;
             let _ = async_receiver
-                .capture_audio_with_retry(std::time::Duration::from_millis(100), 10)
-                .await;
-            let _ = async_receiver
-                .capture_audio_blocking(std::time::Duration::from_secs(5))
+                .capture_audio_timeout(std::time::Duration::from_millis(100))
                 .await;
 
             let _ = async_receiver
-                .capture_metadata(std::time::Duration::from_millis(100))
+                .capture_metadata(std::time::Duration::from_secs(5))
                 .await;
             let _ = async_receiver
-                .capture_metadata_with_retry(std::time::Duration::from_millis(100), 10)
-                .await;
-            let _ = async_receiver
-                .capture_metadata_blocking(std::time::Duration::from_secs(5))
+                .capture_metadata_timeout(std::time::Duration::from_millis(100))
                 .await;
         }
     };
@@ -1118,7 +1100,7 @@ fn test_line_stride_or_size_to_raw_compressed() {
 
 #[test]
 fn test_video_frame_from_raw_uncompressed_bgra() {
-    use crate::frames::{FourCCVideoType, LineStrideOrSize};
+    use crate::frames::{LineStrideOrSize, PixelFormat};
 
     // Test that from_raw reads ONLY line_stride_in_bytes for uncompressed formats
     let test_width = 1920;
@@ -1144,7 +1126,7 @@ fn test_video_frame_from_raw_uncompressed_bgra() {
         // Verify data size calculation
         let expected_size = (line_stride * test_height) as usize;
         assert_eq!(frame.data.len(), expected_size);
-        assert_eq!(frame.fourcc, FourCCVideoType::BGRA);
+        assert_eq!(frame.pixel_format, PixelFormat::BGRA);
 
         drop(frame);
         Vec::from_raw_parts(c_frame.p_data, expected_size, expected_size);
@@ -1152,19 +1134,17 @@ fn test_video_frame_from_raw_uncompressed_bgra() {
 }
 
 #[test]
-fn test_video_frame_from_raw_compressed() {
-    use crate::frames::{FourCCVideoType, LineStrideOrSize};
-
-    // Test that from_raw reads ONLY data_size_in_bytes for compressed/unknown formats
+fn test_video_frame_from_raw_unknown_format_returns_error() {
+    // Test that from_raw returns an error for unknown pixel formats
     let test_width = 1920;
     let test_height = 1080;
-    let data_size = 512000; // Compressed size
+    let data_size = 512000;
 
-    // Create a frame with Max FourCC (compressed/unknown format)
+    // Create a frame with an invalid/unknown FourCC
     let mut c_frame: NDIlib_video_frame_v2_t = unsafe { std::mem::zeroed() };
     c_frame.xres = test_width;
     c_frame.yres = test_height;
-    c_frame.FourCC = NDIlib_FourCC_video_type_e_NDIlib_FourCC_video_type_max;
+    c_frame.FourCC = 0xFFFFFFFF; // Invalid FourCC code
     c_frame.__bindgen_anon_1.data_size_in_bytes = data_size;
 
     let mut data = vec![0u8; data_size as usize];
@@ -1172,35 +1152,27 @@ fn test_video_frame_from_raw_compressed() {
     std::mem::forget(data);
 
     unsafe {
-        let frame = VideoFrame::from_raw(&c_frame).unwrap();
+        let result = VideoFrame::from_raw(&c_frame);
+        assert!(result.is_err());
 
-        // Should have DataSizeBytes variant
-        match frame.line_stride_or_size {
-            LineStrideOrSize::DataSizeBytes(size) => {
-                assert_eq!(size, data_size);
-            }
-            LineStrideOrSize::LineStrideBytes(_) => {
-                panic!("Expected DataSizeBytes for compressed format");
-            }
+        if let Err(Error::InvalidFrame(msg)) = result {
+            assert!(msg.contains("Unknown pixel format FourCC"));
+        } else {
+            panic!("Expected InvalidFrame error for unknown pixel format");
         }
 
-        // Verify data size
-        assert_eq!(frame.data.len(), data_size as usize);
-        assert_eq!(frame.fourcc, FourCCVideoType::Max);
-
-        drop(frame);
         Vec::from_raw_parts(c_frame.p_data, data_size as usize, data_size as usize);
     }
 }
 
 #[test]
 fn test_video_frame_to_raw_roundtrip_uncompressed() {
-    use crate::frames::{FourCCVideoType, LineStrideOrSize, VideoFrame};
+    use crate::frames::{LineStrideOrSize, PixelFormat, VideoFrame};
 
     // Build a video frame with LineStrideBytes
     let frame = VideoFrame::builder()
         .resolution(1920, 1080)
-        .fourcc(FourCCVideoType::BGRA)
+        .pixel_format(PixelFormat::BGRA)
         .build()
         .unwrap();
 
@@ -1225,12 +1197,12 @@ fn test_video_frame_to_raw_roundtrip_uncompressed() {
 
 #[test]
 fn test_video_frame_builder_creates_line_stride_bytes() {
-    use crate::frames::{FourCCVideoType, LineStrideOrSize, VideoFrame};
+    use crate::frames::{LineStrideOrSize, PixelFormat, VideoFrame};
 
     // All builder-created frames should use LineStrideBytes
     let frame = VideoFrame::builder()
         .resolution(640, 480)
-        .fourcc(FourCCVideoType::RGBA)
+        .pixel_format(PixelFormat::RGBA)
         .build()
         .unwrap();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -944,17 +944,35 @@ fn test_tokio_async_receiver_methods_exist() {
             let async_receiver = AsyncReceiver::new(receiver);
 
             // All these methods should exist and be callable
-            let _ = async_receiver.capture_video(100).await;
-            let _ = async_receiver.capture_video_with_retry(100, 10).await;
-            let _ = async_receiver.capture_video_blocking(5000).await;
+            let _ = async_receiver
+                .capture_video(std::time::Duration::from_millis(100))
+                .await;
+            let _ = async_receiver
+                .capture_video_with_retry(std::time::Duration::from_millis(100), 10)
+                .await;
+            let _ = async_receiver
+                .capture_video_blocking(std::time::Duration::from_secs(5))
+                .await;
 
-            let _ = async_receiver.capture_audio(100).await;
-            let _ = async_receiver.capture_audio_with_retry(100, 10).await;
-            let _ = async_receiver.capture_audio_blocking(5000).await;
+            let _ = async_receiver
+                .capture_audio(std::time::Duration::from_millis(100))
+                .await;
+            let _ = async_receiver
+                .capture_audio_with_retry(std::time::Duration::from_millis(100), 10)
+                .await;
+            let _ = async_receiver
+                .capture_audio_blocking(std::time::Duration::from_secs(5))
+                .await;
 
-            let _ = async_receiver.capture_metadata(100).await;
-            let _ = async_receiver.capture_metadata_with_retry(100, 10).await;
-            let _ = async_receiver.capture_metadata_blocking(5000).await;
+            let _ = async_receiver
+                .capture_metadata(std::time::Duration::from_millis(100))
+                .await;
+            let _ = async_receiver
+                .capture_metadata_with_retry(std::time::Duration::from_millis(100), 10)
+                .await;
+            let _ = async_receiver
+                .capture_metadata_blocking(std::time::Duration::from_secs(5))
+                .await;
         }
     };
 }
@@ -1019,17 +1037,35 @@ fn test_async_std_async_receiver_methods_exist() {
             let async_receiver = AsyncReceiver::new(receiver);
 
             // All these methods should exist and be callable
-            let _ = async_receiver.capture_video(100).await;
-            let _ = async_receiver.capture_video_with_retry(100, 10).await;
-            let _ = async_receiver.capture_video_blocking(5000).await;
+            let _ = async_receiver
+                .capture_video(std::time::Duration::from_millis(100))
+                .await;
+            let _ = async_receiver
+                .capture_video_with_retry(std::time::Duration::from_millis(100), 10)
+                .await;
+            let _ = async_receiver
+                .capture_video_blocking(std::time::Duration::from_secs(5))
+                .await;
 
-            let _ = async_receiver.capture_audio(100).await;
-            let _ = async_receiver.capture_audio_with_retry(100, 10).await;
-            let _ = async_receiver.capture_audio_blocking(5000).await;
+            let _ = async_receiver
+                .capture_audio(std::time::Duration::from_millis(100))
+                .await;
+            let _ = async_receiver
+                .capture_audio_with_retry(std::time::Duration::from_millis(100), 10)
+                .await;
+            let _ = async_receiver
+                .capture_audio_blocking(std::time::Duration::from_secs(5))
+                .await;
 
-            let _ = async_receiver.capture_metadata(100).await;
-            let _ = async_receiver.capture_metadata_with_retry(100, 10).await;
-            let _ = async_receiver.capture_metadata_blocking(5000).await;
+            let _ = async_receiver
+                .capture_metadata(std::time::Duration::from_millis(100))
+                .await;
+            let _ = async_receiver
+                .capture_metadata_with_retry(std::time::Duration::from_millis(100), 10)
+                .await;
+            let _ = async_receiver
+                .capture_metadata_blocking(std::time::Duration::from_secs(5))
+                .await;
         }
     };
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -879,7 +879,7 @@ fn test_receiver_presets_are_distinct() {
 fn test_tokio_async_receiver_creation() {
     use crate::{
         finder::{Source, SourceAddress},
-        receiver::ReceiverOptionsBuilder,
+        receiver::{Receiver, ReceiverOptionsBuilder},
         NDI,
     };
 
@@ -906,9 +906,8 @@ fn test_tokio_async_receiver_creation() {
         if false {
             use std::sync::Arc;
             let ndi = Arc::new(NDI::new().unwrap());
-            let receiver = ReceiverOptionsBuilder::snapshot_preset(source)
-                .build(&ndi)
-                .unwrap();
+            let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+            let receiver = Receiver::new(&ndi, &options).unwrap();
             let async_receiver = AsyncReceiver::new(receiver);
             let _cloned = async_receiver.clone();
         }
@@ -923,7 +922,7 @@ fn test_tokio_async_receiver_methods_exist() {
 
     use crate::{
         finder::{Source, SourceAddress},
-        receiver::ReceiverOptionsBuilder,
+        receiver::{Receiver, ReceiverOptionsBuilder},
         tokio::AsyncReceiver,
         NDI,
     };
@@ -938,9 +937,8 @@ fn test_tokio_async_receiver_methods_exist() {
         if false {
             use std::sync::Arc;
             let ndi = Arc::new(NDI::new().unwrap());
-            let receiver = ReceiverOptionsBuilder::snapshot_preset(source)
-                .build(&ndi)
-                .unwrap();
+            let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+            let receiver = Receiver::new(&ndi, &options).unwrap();
             let async_receiver = AsyncReceiver::new(receiver);
 
             // All these methods should exist and be callable
@@ -982,7 +980,7 @@ fn test_tokio_async_receiver_methods_exist() {
 fn test_async_std_async_receiver_creation() {
     use crate::{
         finder::{Source, SourceAddress},
-        receiver::ReceiverOptionsBuilder,
+        receiver::{Receiver, ReceiverOptionsBuilder},
         NDI,
     };
 
@@ -1000,9 +998,8 @@ fn test_async_std_async_receiver_creation() {
         if false {
             use std::sync::Arc;
             let ndi = Arc::new(NDI::new().unwrap());
-            let receiver = ReceiverOptionsBuilder::snapshot_preset(source)
-                .build(&ndi)
-                .unwrap();
+            let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+            let receiver = Receiver::new(&ndi, &options).unwrap();
             let async_receiver = AsyncReceiver::new(receiver);
             let _cloned = async_receiver.clone();
         }
@@ -1017,7 +1014,7 @@ fn test_async_std_async_receiver_methods_exist() {
     use crate::{
         async_std::AsyncReceiver,
         finder::{Source, SourceAddress},
-        receiver::ReceiverOptionsBuilder,
+        receiver::{Receiver, ReceiverOptionsBuilder},
         NDI,
     };
 
@@ -1031,9 +1028,8 @@ fn test_async_std_async_receiver_methods_exist() {
         if false {
             use std::sync::Arc;
             let ndi = Arc::new(NDI::new().unwrap());
-            let receiver = ReceiverOptionsBuilder::snapshot_preset(source)
-                .build(&ndi)
-                .unwrap();
+            let options = ReceiverOptionsBuilder::snapshot_preset(source).build();
+            let receiver = Receiver::new(&ndi, &options).unwrap();
             let async_receiver = AsyncReceiver::new(receiver);
 
             // All these methods should exist and be callable

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1144,7 +1144,7 @@ fn test_video_frame_from_raw_unknown_format_returns_error() {
     let mut c_frame: NDIlib_video_frame_v2_t = unsafe { std::mem::zeroed() };
     c_frame.xres = test_width;
     c_frame.yres = test_height;
-    c_frame.FourCC = 0xFFFFFFFF; // Invalid FourCC code
+    c_frame.FourCC = -1i32 as _; // Invalid FourCC code (0xFFFFFFFF)
     c_frame.__bindgen_anon_1.data_size_in_bytes = data_size;
 
     let mut data = vec![0u8; data_size as usize];

--- a/tests/async_token_stress.rs
+++ b/tests/async_token_stress.rs
@@ -1,4 +1,4 @@
-use grafton_ndi::{BorrowedVideoFrame, FourCCVideoType, SenderOptions, NDI};
+use grafton_ndi::{BorrowedVideoFrame, PixelFormat, SenderOptions, NDI};
 
 use std::{
     sync::{Arc, Mutex},
@@ -37,14 +37,8 @@ fn stress_test_async_token_drops() -> Result<(), grafton_ndi::Error> {
                     *byte = ((i + frame_num + thread_id * 1000) % 256) as u8;
                 }
 
-                let borrowed_frame = BorrowedVideoFrame::from_buffer(
-                    &buffer,
-                    1920,
-                    1080,
-                    FourCCVideoType::BGRA,
-                    30,
-                    1,
-                );
+                let borrowed_frame =
+                    BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
 
                 let token = sender.send_video_async(&borrowed_frame);
 
@@ -93,7 +87,7 @@ fn test_immediate_sender_drop() -> Result<(), grafton_ndi::Error> {
         {
             let buffer = vec![0u8; 1920 * 1080 * 4];
             let borrowed_frame =
-                BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, FourCCVideoType::BGRA, 30, 1);
+                BorrowedVideoFrame::from_buffer(&buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
 
             let _token = sender.send_video_async(&borrowed_frame);
         }
@@ -119,7 +113,7 @@ fn test_flush_async() -> Result<(), grafton_ndi::Error> {
 
     for buffer in buffers.iter() {
         let borrowed_frame =
-            BorrowedVideoFrame::from_buffer(buffer, 1920, 1080, FourCCVideoType::BGRA, 30, 1);
+            BorrowedVideoFrame::from_buffer(buffer, 1920, 1080, PixelFormat::BGRA, 30, 1);
         let token = sender.send_video_async(&borrowed_frame);
         drop(token);
     }

--- a/tests/async_token_stress.rs
+++ b/tests/async_token_stress.rs
@@ -22,7 +22,7 @@ fn stress_test_async_token_drops() -> Result<(), grafton_ndi::Error> {
             let send_options = SenderOptions::builder(format!("Stress Test Sender {thread_id}"))
                 .clock_video(true)
                 .clock_audio(false)
-                .build()?;
+                .build();
             let mut sender = grafton_ndi::Sender::new(&ndi_clone, &send_options)?;
 
             sender.on_async_video_done(move |_len| {
@@ -87,7 +87,7 @@ fn test_immediate_sender_drop() -> Result<(), grafton_ndi::Error> {
         let send_options = SenderOptions::builder("Immediate Drop Test")
             .clock_video(true)
             .clock_audio(false)
-            .build()?;
+            .build();
         let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
         {
@@ -112,7 +112,7 @@ fn test_flush_async() -> Result<(), grafton_ndi::Error> {
     let send_options = SenderOptions::builder("Flush Test")
         .clock_video(true)
         .clock_audio(false)
-        .build()?;
+        .build();
     let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
     let buffers: Vec<Vec<u8>> = (0..10).map(|i| vec![i as u8; 1920 * 1080 * 4]).collect();

--- a/tests/callback_lifetime_stress.rs
+++ b/tests/callback_lifetime_stress.rs
@@ -39,7 +39,7 @@ fn test_rapid_sender_lifecycle() -> Result<(), grafton_ndi::Error> {
         let send_options = SenderOptions::builder(format!("Lifecycle Test {iteration}"))
             .clock_video(true)
             .clock_audio(false)
-            .build()?;
+            .build();
         let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
         let counter = callback_count.clone();
@@ -104,7 +104,7 @@ fn test_concurrent_sender_lifecycle() -> Result<(), grafton_ndi::Error> {
                     SenderOptions::builder(format!("Thread {thread_id} Iter {iteration}"))
                         .clock_video(true)
                         .clock_audio(false)
-                        .build()?;
+                        .build();
                 let mut sender = grafton_ndi::Sender::new(&ndi_clone, &send_options)?;
 
                 let counter = callback_count.clone();
@@ -170,7 +170,7 @@ fn test_no_callbacks_after_drop() -> Result<(), grafton_ndi::Error> {
         let send_options = SenderOptions::builder("Post-Drop Test")
             .clock_video(true)
             .clock_audio(false)
-            .build()?;
+            .build();
         let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
         let counter = callback_count.clone();
@@ -219,7 +219,7 @@ fn test_flush_waits_for_callback() -> Result<(), grafton_ndi::Error> {
     let send_options = SenderOptions::builder("Flush Wait Test")
         .clock_video(true)
         .clock_audio(false)
-        .build()?;
+        .build();
     let mut sender = grafton_ndi::Sender::new(&ndi, &send_options)?;
 
     let counter = callback_count.clone();

--- a/tests/callback_lifetime_stress.rs
+++ b/tests/callback_lifetime_stress.rs
@@ -6,7 +6,7 @@
 /// These tests are ignored by default because they take ~100 seconds to run.
 /// Run them explicitly with: cargo test --features advanced_sdk --test callback_lifetime_stress -- --ignored
 #[cfg(feature = "advanced_sdk")]
-use grafton_ndi::{BorrowedVideoFrame, FourCCVideoType, SenderOptions, NDI};
+use grafton_ndi::{BorrowedVideoFrame, PixelFormat, SenderOptions, NDI};
 
 #[cfg(feature = "advanced_sdk")]
 use std::{
@@ -50,7 +50,7 @@ fn test_rapid_sender_lifecycle() -> Result<(), grafton_ndi::Error> {
         let buffer = vec![0u8; 640 * 480 * 4];
         for _ in 0..2 {
             let borrowed_frame =
-                BorrowedVideoFrame::from_buffer(&buffer, 640, 480, FourCCVideoType::BGRA, 30, 1);
+                BorrowedVideoFrame::from_buffer(&buffer, 640, 480, PixelFormat::BGRA, 30, 1);
             let _token = sender.send_video_async(&borrowed_frame);
         }
 
@@ -118,7 +118,7 @@ fn test_concurrent_sender_lifecycle() -> Result<(), grafton_ndi::Error> {
                         &buffer,
                         640,
                         480,
-                        FourCCVideoType::BGRA,
+                        PixelFormat::BGRA,
                         30,
                         1,
                     );
@@ -181,7 +181,7 @@ fn test_no_callbacks_after_drop() -> Result<(), grafton_ndi::Error> {
         let buffer = vec![0u8; 640 * 480 * 4];
         for _ in 0..3 {
             let borrowed_frame =
-                BorrowedVideoFrame::from_buffer(&buffer, 640, 480, FourCCVideoType::BGRA, 30, 1);
+                BorrowedVideoFrame::from_buffer(&buffer, 640, 480, PixelFormat::BGRA, 30, 1);
             let _token = sender.send_video_async(&borrowed_frame);
         }
 
@@ -230,7 +230,7 @@ fn test_flush_waits_for_callback() -> Result<(), grafton_ndi::Error> {
     let buffer = vec![0u8; 640 * 480 * 4];
     for _ in 0..3 {
         let borrowed_frame =
-            BorrowedVideoFrame::from_buffer(&buffer, 640, 480, FourCCVideoType::BGRA, 30, 1);
+            BorrowedVideoFrame::from_buffer(&buffer, 640, 480, PixelFormat::BGRA, 30, 1);
         let _token = sender.send_video_async(&borrowed_frame);
     }
 


### PR DESCRIPTION
## Summary

This PR completes **all 8 steps** of the API stabilization plan from issue #24, preparing the crate for a 1.0 release with a clean, consistent, idiomatic Rust API.

### Completed Steps

✅ **Step 1: Duration-based Timeouts**
- All timeout parameters now use `std::time::Duration` instead of `u32` milliseconds
- Added `MAX_TIMEOUT` constant and `to_ms_checked()` helper for overflow protection
- No silent truncation - errors are explicit

✅ **Step 2: Builder Pattern Consistency**
- Both `ReceiverOptionsBuilder` and `SenderOptionsBuilder` are now infallible
- Validation moved to `Receiver::new()` and `Sender::new()` constructors
- Symmetric API pattern across all builders

✅ **Step 3: Simplified Capture API**
- Reduced from 3 confusing variants to 2 clear variants per frame type
- `capture_*()` - Primary, reliable method that retries internally
- `capture_*_timeout()` - Polling variant that returns `Option`
- Removed deprecated `Receiver::capture()` composite API

✅ **Step 4: Type Renames & Forward Compatibility**
- `FourCCVideoType` → `PixelFormat`
- `FrameFormatType` → `ScanType`
- `AudioType` → `AudioFormat`
- All enums marked `#[non_exhaustive]`
- Removed `Max` sentinel variants
- Unknown format codes now return proper errors

✅ **Step 5: Finder Polish** (Already Complete)
- Removed `get_` prefixes from all Finder methods
- Added `find_sources()` convenience method
- All methods use `Duration` parameters

✅ **Step 6: Sender API Polish**
- `get_tally()` → `tally()` returns `Result<Option<Tally>>`
- `get_no_connections()` → `connection_count()` returns `Result<u32>`
- `get_source_name()` → `source()` returns owned `Source`
- Added `AsyncVideoToken::wait()` and `is_complete()` methods

✅ **Step 7: Runtime Constructor**
- Removed `NDI::acquire()` - only `NDI::new()` remains
- Single obvious constructor pattern

✅ **Step 8: Documentation & Examples**
- Updated README, CHANGELOG, and all doc comments
- Comprehensive migration guide in CHANGELOG
- All examples updated to use new API
- All doc tests pass (64 passed, 2 ignored as expected)

### Quality Verification

✅ **cargo fmt** - Code properly formatted
✅ **cargo clippy --all-targets --all-features** - **Zero warnings**
✅ **cargo test --lib** - All 44 unit tests pass
✅ **cargo test --doc** - All 64 doc tests pass (2 ignored)
✅ **cargo build --examples** - All examples compile
✅ **cargo build --release --all-features** - Release build succeeds

### Breaking Changes

This PR contains extensive breaking changes as documented in the CHANGELOG. All breaking changes are necessary for API stabilization and consistency.

Key migration patterns:
- Timeouts: `5000_u32` → `Duration::from_secs(5)`
- Builders: `.build(&ndi)?` → `.build()` + `::new(&ndi, &opts)?`
- Capture: `capture_video_blocking()` → `capture_video()`
- Types: `FourCCVideoType::BGRA` → `PixelFormat::BGRA`
- Finder: `get_sources()` → `sources()`
- Sender: `get_tally()` → `tally()`

### Files Modified

- Core API: `src/receiver.rs`, `src/sender.rs`, `src/finder.rs`, `src/frames.rs`, `src/runtime.rs`
- Async: `src/async_runtime.rs` (both tokio and async-std adapters)
- Exports: `src/lib.rs`
- Documentation: `README.md`, `CHANGELOG.md`
- All doc comment examples updated

### Test Plan

All existing tests continue to pass with updated expectations. The test suite validates:
- Duration conversion and overflow handling
- Builder patterns and validation
- Frame capture behavior
- Type conversions and `#[non_exhaustive]` enums
- Async adapter behavior
- Documentation examples

### Acceptance Criteria (From Issue #24, Section 10)

✅ API surface matches the plan (functions, types, names, signatures)
✅ No `u32` timeouts in public API - `Duration` everywhere with overflow errors
✅ No legacy/deprecated public items remain
✅ Enums are `#[non_exhaustive]` without `Max` sentinels
✅ Builders are infallible; validation is in `::new()`
✅ Async adapters reflect new names and semantics
✅ All examples and docs updated
✅ `cargo clippy --all-targets --all-features` clean
✅ `cargo fmt` clean
✅ Full test suite passes

Closes #24