### PR TITLE
Corrected interleaved audio handling

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -125,16 +125,18 @@ fn test_audio_frame_channel_data_interleaved() {
     use crate::AudioLayout;
 
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let samples = 3;
     let frame = AudioFrame::builder()
         .sample_rate(48000)
         .channels(2)
-        .samples(3)
+        .samples(samples)
         .data(data)
-        .layout(AudioLayout::Interleaved)
+        .layout(AudioLayout::Interleaved_f32)
         .build()
         .unwrap();
 
-    assert_eq!(frame.channel_stride_in_bytes, 0);
+    // 4 bytes per f32 sample
+    assert_eq!(frame.channel_stride_in_bytes, 4i32 * samples as i32);
 
     let ch0 = frame.channel_data(0).unwrap();
     assert_eq!(ch0, vec![1.0, 3.0, 5.0]);


### PR DESCRIPTION
The NDI SDK expects planar audio format by default. Instead of storing interleaved data with stride=0 (which doesnt do anything), use the SDK's utility function to convert interleaved input to planar format during frame construction. This seemed like the simplest path forward to get grafton-ndi to accept and handle f32 interleaved audio properly. 

The idea is that an AudioFrame's data buffer will always be in planar format. When creating a new AudioFrame with the Builder and AudioLayout::Interleaved, it will be converted to planar during `build()`. 

- Remove interleaved format handling from channel_data()
- Add NDIlib_util_audio_from_interleaved_32f_v3 conversion in build()
- Rename AudioLayout::Interleaved to Interleaved_f32 (this one might be debatable for backwards compatibility, but since the SDK also provides utility functions for 16s and 32s, my suggested renaming is more scalable. 

Tests are passing. Closes #45 
Let me know what you think! 