### PR TITLE
fix: harden async video lifecycle (#44)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafton-ndi"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.75"
 build = "build.rs"


### PR DESCRIPTION
## Summary

- Eliminates double-callback in async video lifecycle by consolidating user callback invocation to a single site in `AsyncVideoToken::drop`
- Gates all completion-signal logic on `cfg(all(feature = "advanced_sdk", has_async_completion_callback))`, eliminating the "reset-without-signal" mode
- Fixes unsafe `Inner::drop` teardown order (now flushes before unregistering callback)
- Replaces `try_wait_timeout` (could skip waiting under lock contention) with deterministic `wait_timeout` + null-frame flush fallback
- Removes unused fields (`video_buffer_ptr`, `video_buffer_len`), `TryWaitResult` enum, and all `eprintln!` warnings from library code
- Extracts `flush_null_frame` helper to eliminate 3x code duplication

Closes #44

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo test --lib` — 117 tests pass
- [x] `cargo test --doc` — 80 tests pass
- [x] `cargo build --release` clean
- [x] `cargo build --examples` clean
- [x] `cargo check --no-default-features` clean
- [x] `cargo check --features advanced_sdk` clean
- [x] All pre-commit hooks pass (fmt, clippy across all feature combos, tests, doc)
- [x] No remaining references to `TryWaitResult`, `try_wait_timeout`, `video_buffer_ptr`, or `video_buffer_len`