### PR TITLE
Validate FrameSync layouts before exposing buffers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,6 +146,9 @@ jobs:
     needs: [format, test-and-lint, semver]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -163,7 +166,11 @@ jobs:
           shared-key: "rust-cache-windows"
           save-if: false  # Don't save cache in publish job
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish to crates.io
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Regression coverage for async flush pointer semantics**: Added focused test coverage proving async flush uses a true null frame pointer when flushing the NDI async video pipeline.
+- **Explicit FrameSync audio requests**: Added `FrameSyncAudioRequest` so audio capture and query modes no longer rely on magic zero integer triples.
 
 ### Fixed
 
 - **Async sender flush now passes a true NULL frame pointer**: `flush_null_frame` now calls `NDIlib_send_send_video_async_v2` with `ptr::null()` instead of passing a pointer to a zeroed `NDIlib_video_frame_v2_t`, matching the NDI SDK's async flush contract. Thanks to [@FlowingSPDG](https://github.com/FlowingSPDG) for identifying and fixing this in [#51](https://github.com/GrantSparks/grafton-ndi/pull/51).
 - **CI handles rotated NDI SDK downloads**: Linux, macOS, and Windows NDI setup actions now accept a small allowlist of known-good installer hashes and use current hash-based cache keys, so CI can recover when NDI rotates installer payloads behind stable download URLs.
+- **FrameSync borrowed frames validate SDK layouts before exposing buffers**: FrameSync video and audio refs now use the shared cached layout validators, checked arithmetic, channel-stride validation, and RAII cleanup on validation errors. Malformed SDK metadata is reported as `Error::InvalidFrame(_)` instead of `None`, empty slices, panics, or unchecked slice lengths.
 
 ### Changed
 
+- **Breaking FrameSync API cleanup**: `FrameSync::capture_video()` now returns `Result<Option<FrameSyncVideoRef>>`, `capture_video_owned()` now returns `Result<Option<VideoFrame>>`, `capture_audio()` takes `FrameSyncAudioRequest` and returns `Result<FrameSyncAudioRef>`, and `capture_audio_owned()` returns `Result<Option<AudioFrame>>` for query/no-source states without sample buffers.
+- **FrameSync audio exposes validated empty/query state**: `FrameSyncAudioRef::is_empty()` identifies the documented zero-length query/no-source state, and `data()`/channel accessors use cached validated stride information.
 - **GitHub Actions are Node 24-ready**: Updated GitHub-maintained checkout/cache actions to Node 24-compatible major versions ahead of GitHub's Node 20 runner deprecation.
 - **CI matrix failures are no longer hidden by fail-fast cancellation**: Rust test/lint and semver matrices now keep running after one platform fails, making platform-specific SDK setup failures visible.
 
@@ -229,24 +233,30 @@ match completion.try_wait_timeout(Duration::from_secs(5), "operation") {
 New `FrameSync` type wraps the NDI FrameSync API, transforming push-based NDI streams into pull-based capture with automatic time-base correction and dynamic audio resampling.
 
 ```rust
-use grafton_ndi::{FrameSync, ScanType};
+use grafton_ndi::{FrameSync, FrameSyncAudioRequest, ScanType};
+use std::num::NonZeroI32;
 
-let frame_sync = FrameSync::new(&receiver)?;
+let frame_sync = FrameSync::new(receiver)?;
 
 // Capture clock-corrected video (returns immediately)
-if let Some(video) = frame_sync.capture_video(ScanType::Progressive) {
+if let Some(video) = frame_sync.capture_video(ScanType::Progressive)? {
     println!("{}x{}", video.width(), video.height());
 }
 
 // Capture resampled audio at requested rate/channels/samples
-let audio = frame_sync.capture_audio(48000, 2, 1024);
+let audio = frame_sync.capture_audio(FrameSyncAudioRequest::Capture {
+    sample_rate: Some(NonZeroI32::new(48_000).unwrap()),
+    channels: Some(NonZeroI32::new(2).unwrap()),
+    samples: NonZeroI32::new(1_024).unwrap(),
+})?;
 
 // Check queue depth
 let depth = frame_sync.audio_queue_depth();
 ```
 
 **New Types:**
-- `FrameSync<'rx>` - Frame synchronizer tied to receiver lifetime
+- `FrameSync` - Frame synchronizer that owns its receiver
+- `FrameSyncAudioRequest` - Explicit audio capture/query request
 - `FrameSyncVideoRef<'fs>` - Zero-copy borrowed video with RAII cleanup
 - `FrameSyncAudioRef<'fs>` - Zero-copy borrowed audio with RAII cleanup
 

--- a/README.md
+++ b/README.md
@@ -157,18 +157,29 @@ let token = sender.send_video_async(&borrowed_frame);
 Wraps a `Receiver` to provide pull-based capture with automatic time-base correction and dynamic audio resampling. Captures always return immediately.
 
 ```rust
-use grafton_ndi::FrameSync;
+use grafton_ndi::{FrameSync, FrameSyncAudioRequest, ScanType};
+use std::num::NonZeroI32;
 
 // FrameSync takes ownership of the receiver
 let frame_sync = FrameSync::new(receiver)?;
 
 // Capture clock-corrected video (returns immediately)
-if let Some(video) = frame_sync.capture_video(ScanType::Progressive) {
+if let Some(video) = frame_sync.capture_video(ScanType::Progressive)? {
     println!("Video: {}x{}", video.width(), video.height());
 }
 
-// Capture resampled audio at requested rate/channels/samples
-let audio = frame_sync.capture_audio(48000, 2, 1024);
+// Capture resampled audio at requested rate/channels/samples.
+let audio = frame_sync.capture_audio(FrameSyncAudioRequest::Capture {
+    sample_rate: Some(NonZeroI32::new(48_000).unwrap()),
+    channels: Some(NonZeroI32::new(2).unwrap()),
+    samples: NonZeroI32::new(1_024).unwrap(),
+})?;
+
+// Query the current source audio format without requesting samples.
+let input = frame_sync.capture_audio(FrameSyncAudioRequest::QueryInput)?;
+if input.is_empty() {
+    println!("No source audio format yet");
+}
 
 // Access the underlying receiver for tally, PTZ, or status
 let recv = frame_sync.receiver();

--- a/examples/NDIlib_Recv_FrameSync.rs
+++ b/examples/NDIlib_Recv_FrameSync.rs
@@ -24,12 +24,14 @@
 //! - Audio sample rate: `cargo run --example NDIlib_Recv_FrameSync -- --audio-rate 44100`
 
 use grafton_ndi::{
-    Error, Finder, FinderOptions, FrameSync, Receiver, ReceiverColorFormat, ReceiverOptions,
-    ScanType, NDI,
+    Error, Finder, FinderOptions, FrameSync, FrameSyncAudioRequest, Receiver, ReceiverColorFormat,
+    ReceiverOptions, ScanType, NDI,
 };
 
 use std::{
-    env, thread,
+    env,
+    num::NonZeroI32,
+    thread,
     time::{Duration, Instant},
 };
 
@@ -114,6 +116,11 @@ fn main() -> Result<(), Error> {
 
     println!("Creating FrameSync for clock-corrected capture...");
     let framesync = FrameSync::new(receiver)?;
+    let audio_request = FrameSyncAudioRequest::Capture {
+        sample_rate: Some(positive_nonzero("audio sample rate", audio_sample_rate)?),
+        channels: Some(positive_nonzero("audio channels", audio_channels)?),
+        samples: positive_nonzero("audio samples", audio_samples)?,
+    };
 
     println!("FrameSync created successfully");
     println!("\nCapturing {frame_count} frames with FrameSync...\n");
@@ -131,7 +138,7 @@ fn main() -> Result<(), Error> {
         let loop_start = Instant::now();
 
         // Capture video - always returns immediately
-        if let Some(video) = framesync.capture_video(ScanType::Progressive) {
+        if let Some(video) = framesync.capture_video(ScanType::Progressive)? {
             // Check if this is the same frame as last time (FrameSync may repeat frames)
             if video.timecode() == last_video_timecode && video_frames > 0 {
                 duplicate_frames += 1;
@@ -160,12 +167,12 @@ fn main() -> Result<(), Error> {
         }
 
         // Capture audio - always returns immediately (with silence if needed)
-        let audio = framesync.capture_audio(audio_sample_rate, audio_channels, audio_samples);
+        let audio = framesync.capture_audio(audio_request)?;
         audio_samples_total += audio.num_samples() as usize;
 
         if video_frames == 1 {
             // Print audio info on first video frame
-            if audio.sample_rate() > 0 {
+            if !audio.is_empty() {
                 println!("Audio stream info:");
                 println!("  Sample rate: {} Hz", audio.sample_rate());
                 println!("  Channels: {}", audio.num_channels());
@@ -220,4 +227,14 @@ fn main() -> Result<(), Error> {
     println!("\nExample completed successfully!");
 
     Ok(())
+}
+
+fn positive_nonzero(name: &str, value: i32) -> Result<NonZeroI32, Error> {
+    if value > 0 {
+        Ok(NonZeroI32::new(value).expect("positive values are non-zero"))
+    } else {
+        Err(Error::InvalidConfiguration(format!(
+            "{name} must be positive, got {value}"
+        )))
+    }
 }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -150,23 +150,25 @@ impl PixelFormatInfo {
     /// - **Packed RGB/YUV** (BGRA/BGRX/RGBA/RGBX/UYVY/UYVA/P216/PA16): `y_stride * height`
     /// - **Planar 4:2:0 YV12/I420**: `Y + U + V` where:
     ///   - Y plane: `y_stride * height`
-    ///   - U plane: `(y_stride/2) * ceil(height/2)`
-    ///   - V plane: `(y_stride/2) * ceil(height/2)`
+    ///   - U plane: `ceil(y_stride/2) * ceil(height/2)`
+    ///   - V plane: `ceil(y_stride/2) * ceil(height/2)`
     /// - **Semi-planar 4:2:0 NV12**: `Y + UV` where:
     ///   - Y plane: `y_stride * height`
     ///   - UV plane: `y_stride * ceil(height/2)`
     #[must_use]
     pub const fn buffer_len(&self, y_stride: i32, height: i32) -> usize {
-        let y_size = (y_stride as usize) * (height as usize);
-        let chroma_height = ((height + 1) / 2) as usize;
+        let y_stride = y_stride as usize;
+        let height = height as usize;
+        let y_size = y_stride * height;
+        let chroma_height = (height / 2) + (height % 2);
 
         match self.category {
             FormatCategory::Packed => y_size,
             FormatCategory::Planar420 => {
                 // Planar 4:2:0: Y + U + V
                 // U and V planes each have half width and half height
-                let u_stride = (y_stride / 2) as usize;
-                let v_stride = (y_stride / 2) as usize;
+                let u_stride = (y_stride / 2) + (y_stride % 2);
+                let v_stride = (y_stride / 2) + (y_stride % 2);
                 let u_size = u_stride * chroma_height;
                 let v_size = v_stride * chroma_height;
                 y_size + u_size + v_size
@@ -174,7 +176,7 @@ impl PixelFormatInfo {
             FormatCategory::SemiPlanar420 => {
                 // Semi-planar 4:2:0: Y + interleaved UV
                 // UV plane has full width and half height
-                let uv_size = (y_stride as usize) * chroma_height;
+                let uv_size = y_stride * chroma_height;
                 y_size + uv_size
             }
         }
@@ -733,6 +735,13 @@ impl VideoFrame {
         // Use the shared validation helper to validate and compute layout
         let layout = validate_video_layout(c_frame)?;
 
+        Self::from_raw_validated(c_frame, layout)
+    }
+
+    pub(crate) unsafe fn from_raw_validated(
+        c_frame: &NDIlib_video_frame_v2_t,
+        layout: ValidatedVideoLayout,
+    ) -> Result<VideoFrame> {
         // Copy data for ownership
         let slice = slice::from_raw_parts(c_frame.p_data, layout.data_len_bytes);
         let data = slice.to_vec();
@@ -873,9 +882,41 @@ impl VideoFrameBuilder {
         let picture_aspect_ratio = self.picture_aspect_ratio.unwrap_or(16.0 / 9.0);
         let scan_type = self.scan_type.unwrap_or(ScanType::Progressive);
 
-        // Calculate stride and buffer size using the new unified API
-        let stride = pixel_format.line_stride(width);
-        let buffer_size = pixel_format.buffer_size(width, height);
+        if width <= 0 {
+            return Err(Error::InvalidFrame(format!(
+                "Video frame has invalid width: {}",
+                width
+            )));
+        }
+        if height <= 0 {
+            return Err(Error::InvalidFrame(format!(
+                "Video frame has invalid height: {}",
+                height
+            )));
+        }
+        validate_video_dimensions_for_format(pixel_format, width, height)?;
+
+        let width_usize = usize::try_from(width)
+            .map_err(|_| Error::InvalidFrame(format!("Invalid width value: {}", width)))?;
+        let height_usize = usize::try_from(height)
+            .map_err(|_| Error::InvalidFrame(format!("Invalid height value: {}", height)))?;
+
+        // Calculate stride and buffer size using the same checked layout math
+        // as borrowed/owned raw conversion.
+        let stride_usize = min_video_line_stride_checked(pixel_format, width_usize)?;
+        let stride = i32::try_from(stride_usize).map_err(|_| {
+            Error::InvalidFrame(format!(
+                "Video line stride {} exceeds i32 range",
+                stride_usize
+            ))
+        })?;
+        let buffer_size = calculate_buffer_len_checked(pixel_format, stride_usize, height_usize)?;
+        if buffer_size > MAX_VIDEO_BYTES {
+            return Err(Error::InvalidFrame(format!(
+                "Video frame exceeds maximum size: {} bytes > {} bytes",
+                buffer_size, MAX_VIDEO_BYTES
+            )));
+        }
         let data = vec![0u8; buffer_size];
 
         let mut frame = VideoFrame {
@@ -944,9 +985,23 @@ impl AudioFrame {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn from_raw(raw: NDIlib_audio_frame_v3_t) -> Result<AudioFrame> {
         // Use the shared validation helper to validate and compute layout
         let layout = validate_audio_layout(&raw)?;
+
+        Self::from_raw_validated(raw, layout)
+    }
+
+    pub(crate) fn from_raw_validated(
+        raw: NDIlib_audio_frame_v3_t,
+        layout: ValidatedAudioLayout,
+    ) -> Result<AudioFrame> {
+        if layout.is_empty() {
+            return Err(Error::InvalidFrame(
+                "Cannot create owned AudioFrame from an empty audio layout".into(),
+            ));
+        }
 
         // Copy data for ownership
         let slice = unsafe { slice::from_raw_parts(raw.p_data as *const f32, layout.sample_count) };
@@ -964,9 +1019,11 @@ impl AudioFrame {
             num_channels: raw.no_channels,
             num_samples: raw.no_samples,
             timecode: raw.timecode,
-            format: layout.format,
+            format: layout
+                .format()
+                .expect("validate_audio_layout requires a concrete audio format"),
             data,
-            channel_stride_in_bytes: unsafe { raw.__bindgen_anon_1.channel_stride_in_bytes },
+            channel_stride_in_bytes: layout.channel_stride_in_bytes,
             metadata,
             timestamp: raw.timestamp,
         })
@@ -987,14 +1044,17 @@ impl AudioFrame {
     /// Data is always stored in planar format internally. If `AudioLayout::Interleaved`
     /// was specified at build time, the data was converted to planar during construction.
     pub fn channel_data(&self, channel: usize) -> Option<Vec<f32>> {
-        if channel >= self.num_channels as usize {
+        let num_channels = usize::try_from(self.num_channels).ok()?;
+        let samples_per_channel = usize::try_from(self.num_samples).ok()?;
+        let channel_stride_bytes = usize::try_from(self.channel_stride_in_bytes).ok()?;
+
+        if channel >= num_channels || channel_stride_bytes % std::mem::size_of::<f32>() != 0 {
             return None;
         }
 
-        let samples_per_channel = self.num_samples as usize;
-        let stride_in_samples = self.channel_stride_in_bytes as usize / 4; // f32 = 4 bytes
-        let start = channel * stride_in_samples;
-        let end = start + samples_per_channel;
+        let stride_in_samples = channel_stride_bytes / std::mem::size_of::<f32>();
+        let start = channel.checked_mul(stride_in_samples)?;
+        let end = start.checked_add(samples_per_channel)?;
 
         if end <= self.data.len() {
             Some(self.data[start..end].to_vec())
@@ -1418,7 +1478,7 @@ pub(crate) fn validate_video_layout(raw: &NDIlib_video_frame_v2_t) -> Result<Val
         // Uncompressed format: read ONLY line_stride_in_bytes
         let line_stride = unsafe { raw.__bindgen_anon_1.line_stride_in_bytes };
 
-        // Validate dimensions are positive
+        // Validate dimensions are positive before converting to usize.
         if line_stride <= 0 {
             return Err(Error::InvalidFrame(format!(
                 "Uncompressed video frame has invalid line_stride_in_bytes: {}",
@@ -1438,19 +1498,37 @@ pub(crate) fn validate_video_layout(raw: &NDIlib_video_frame_v2_t) -> Result<Val
             )));
         }
 
-        // Use checked arithmetic to prevent overflow
+        validate_video_dimensions_for_format(pixel_format, raw.xres, raw.yres)?;
+
+        // Use checked arithmetic to prevent overflow.
         let line_stride_usize = usize::try_from(line_stride).map_err(|_| {
             Error::InvalidFrame(format!(
                 "Invalid line_stride_in_bytes value: {}",
                 line_stride
             ))
         })?;
+        let xres_usize = usize::try_from(raw.xres)
+            .map_err(|_| Error::InvalidFrame(format!("Invalid xres value: {}", raw.xres)))?;
         let yres_usize = usize::try_from(raw.yres)
             .map_err(|_| Error::InvalidFrame(format!("Invalid yres value: {}", raw.yres)))?;
 
-        // For planar formats, we need to calculate the full buffer size
-        // buffer_len performs: y_stride * height + chroma planes
-        // We need to do this with checked arithmetic
+        let min_stride = min_video_line_stride_checked(pixel_format, xres_usize)?;
+        if line_stride_usize < min_stride {
+            return Err(Error::InvalidFrame(format!(
+                "Video line_stride_in_bytes {} is smaller than minimum row size {} for {:?} width {}",
+                line_stride, min_stride, pixel_format, raw.xres
+            )));
+        }
+
+        if pixel_format.info().is_planar_420() && line_stride_usize % 2 != 0 {
+            return Err(Error::InvalidFrame(format!(
+                "Planar 4:2:0 video frame has odd line_stride_in_bytes: {}",
+                line_stride
+            )));
+        }
+
+        // For planar formats, calculate the full buffer size with checked
+        // arithmetic instead of PixelFormatInfo::buffer_len's unchecked casts.
         let calculated_size =
             calculate_buffer_len_checked(pixel_format, line_stride_usize, yres_usize)?;
 
@@ -1509,6 +1587,32 @@ pub(crate) fn validate_video_layout(raw: &NDIlib_video_frame_v2_t) -> Result<Val
     })
 }
 
+fn validate_video_dimensions_for_format(
+    pixel_format: PixelFormat,
+    width: i32,
+    height: i32,
+) -> Result<()> {
+    if pixel_format.info().is_planar_420() && (width % 2 != 0 || height % 2 != 0) {
+        return Err(Error::InvalidFrame(format!(
+            "Planar 4:2:0 video frames require even dimensions, got {}x{}",
+            width, height
+        )));
+    }
+
+    Ok(())
+}
+
+fn min_video_line_stride_checked(pixel_format: PixelFormat, width: usize) -> Result<usize> {
+    width
+        .checked_mul(pixel_format.info().bytes_per_pixel() as usize)
+        .ok_or_else(|| {
+            Error::InvalidFrame(format!(
+                "Video line stride overflow for {:?} width {}",
+                pixel_format, width
+            ))
+        })
+}
+
 /// Calculate buffer length with checked arithmetic.
 ///
 /// This is the checked version of `PixelFormatInfo::buffer_len`, which uses
@@ -1531,9 +1635,14 @@ fn calculate_buffer_len_checked(
     match info.category() {
         FormatCategory::Packed => Ok(y_size),
         FormatCategory::Planar420 => {
+            if height % 2 != 0 || y_stride % 2 != 0 {
+                return Err(Error::InvalidFrame(
+                    "Planar 4:2:0 video frames require even height and stride".into(),
+                ));
+            }
             // Planar 4:2:0: Y + U + V
             // U and V planes each have half width and half height
-            let chroma_height = height.div_ceil(2);
+            let chroma_height = height / 2;
             let u_stride = y_stride / 2;
             let v_stride = y_stride / 2;
 
@@ -1552,9 +1661,14 @@ fn calculate_buffer_len_checked(
             Ok(total)
         }
         FormatCategory::SemiPlanar420 => {
+            if height % 2 != 0 {
+                return Err(Error::InvalidFrame(
+                    "Semi-planar 4:2:0 video frames require even height".into(),
+                ));
+            }
             // Semi-planar 4:2:0: Y + interleaved UV
             // UV plane has full width and half height
-            let chroma_height = height.div_ceil(2);
+            let chroma_height = height / 2;
             let uv_size = y_stride
                 .checked_mul(chroma_height)
                 .ok_or_else(|| Error::InvalidFrame("Video UV-plane size overflow".into()))?;
@@ -1571,15 +1685,48 @@ fn calculate_buffer_len_checked(
 /// Validated audio frame layout information.
 ///
 /// This struct holds pre-validated layout information for an audio frame,
-/// including the computed sample count. Creating this struct performs all
-/// necessary bounds checking, so consumers can safely use the cached values
-/// without re-validation.
+/// including the channel stride and computed backing sample count. Creating
+/// this struct performs all necessary bounds checking, so consumers can safely
+/// use the cached values without re-validation.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ValidatedAudioLayout {
-    /// The validated audio format.
-    pub format: AudioFormat,
-    /// The validated total sample count (samples × channels).
+    /// The validated audio format, or `None` for a query/no-source empty state.
+    pub format: Option<AudioFormat>,
+    /// The validated sample rate.
+    pub sample_rate: i32,
+    /// The validated channel count.
+    pub no_channels: usize,
+    /// The validated samples per channel.
+    pub no_samples: usize,
+    /// The validated channel stride in bytes.
+    pub channel_stride_in_bytes: i32,
+    /// The validated channel stride in `f32` samples.
+    pub channel_stride_samples: usize,
+    /// The validated backing sample count. For strided planar audio this may be
+    /// larger than `no_channels * no_samples` because it includes inter-channel
+    /// padding up to the last channel's final sample.
     pub sample_count: usize,
+}
+
+impl ValidatedAudioLayout {
+    pub(crate) fn is_empty(self) -> bool {
+        self.sample_count == 0
+    }
+
+    pub(crate) fn format(self) -> Option<AudioFormat> {
+        self.format
+    }
+
+    pub(crate) fn channel_range(self, channel: usize) -> Option<std::ops::Range<usize>> {
+        if self.is_empty() || channel >= self.no_channels {
+            return None;
+        }
+
+        let start = channel.checked_mul(self.channel_stride_samples)?;
+        let end = start.checked_add(self.no_samples)?;
+
+        (end <= self.sample_count).then_some(start..end)
+    }
 }
 
 /// Validate audio frame layout from raw FFI fields.
@@ -1599,6 +1746,29 @@ pub(crate) struct ValidatedAudioLayout {
 ///
 /// `Ok(ValidatedAudioLayout)` if the frame is valid, or `Err(Error::InvalidFrame(...))` otherwise.
 pub(crate) fn validate_audio_layout(raw: &NDIlib_audio_frame_v3_t) -> Result<ValidatedAudioLayout> {
+    validate_audio_layout_inner(raw, false)
+}
+
+/// Validate a FrameSync audio frame that is allowed to be a documented
+/// query/no-source zero-length state.
+pub(crate) fn validate_audio_layout_allow_empty(
+    raw: &NDIlib_audio_frame_v3_t,
+) -> Result<ValidatedAudioLayout> {
+    validate_audio_layout_inner(raw, true)
+}
+
+fn validate_audio_layout_inner(
+    raw: &NDIlib_audio_frame_v3_t,
+    allow_empty: bool,
+) -> Result<ValidatedAudioLayout> {
+    if raw.no_samples == 0 {
+        if allow_empty {
+            return validate_empty_audio_layout(raw);
+        }
+
+        return Err(Error::InvalidFrame("Invalid number of samples: 0".into()));
+    }
+
     if raw.p_data.is_null() {
         return Err(Error::InvalidFrame(
             "Audio frame has null data pointer".into(),
@@ -1626,6 +1796,15 @@ pub(crate) fn validate_audio_layout(raw: &NDIlib_audio_frame_v3_t) -> Result<Val
         )));
     }
 
+    let format = validate_audio_format(raw.FourCC)?;
+    let channel_stride_in_bytes = unsafe { raw.__bindgen_anon_1.channel_stride_in_bytes };
+    if channel_stride_in_bytes <= 0 {
+        return Err(Error::InvalidFrame(format!(
+            "Invalid channel_stride_in_bytes: {}",
+            channel_stride_in_bytes
+        )));
+    }
+
     // Use checked math to prevent overflow when computing sample count
     let no_samples = usize::try_from(raw.no_samples).map_err(|_| {
         Error::InvalidFrame(format!("Invalid no_samples value: {}", raw.no_samples))
@@ -1635,10 +1814,53 @@ pub(crate) fn validate_audio_layout(raw: &NDIlib_audio_frame_v3_t) -> Result<Val
         Error::InvalidFrame(format!("Invalid no_channels value: {}", raw.no_channels))
     })?;
 
-    let sample_count = no_samples.checked_mul(no_channels).ok_or_else(|| {
+    let channel_stride_bytes = usize::try_from(channel_stride_in_bytes).map_err(|_| {
         Error::InvalidFrame(format!(
-            "Audio sample count overflow: {} samples × {} channels",
-            no_samples, no_channels
+            "Invalid channel_stride_in_bytes value: {}",
+            channel_stride_in_bytes
+        ))
+    })?;
+
+    if channel_stride_bytes % std::mem::size_of::<f32>() != 0 {
+        return Err(Error::InvalidFrame(format!(
+            "channel_stride_in_bytes must be a multiple of {}, got {}",
+            std::mem::size_of::<f32>(),
+            channel_stride_in_bytes
+        )));
+    }
+
+    let minimum_channel_stride = no_samples
+        .checked_mul(std::mem::size_of::<f32>())
+        .ok_or_else(|| {
+            Error::InvalidFrame(format!(
+                "Audio channel stride overflow: {} samples × {} bytes",
+                no_samples,
+                std::mem::size_of::<f32>()
+            ))
+        })?;
+
+    if channel_stride_bytes < minimum_channel_stride {
+        return Err(Error::InvalidFrame(format!(
+            "channel_stride_in_bytes {} is smaller than one channel of audio samples {}",
+            channel_stride_in_bytes, minimum_channel_stride
+        )));
+    }
+
+    let channel_stride_samples = channel_stride_bytes / std::mem::size_of::<f32>();
+    let last_channel_offset = no_channels
+        .checked_sub(1)
+        .and_then(|last| last.checked_mul(channel_stride_samples))
+        .ok_or_else(|| {
+            Error::InvalidFrame(format!(
+                "Audio channel offset overflow: {} channels × {} stride samples",
+                no_channels, channel_stride_samples
+            ))
+        })?;
+
+    let sample_count = last_channel_offset.checked_add(no_samples).ok_or_else(|| {
+        Error::InvalidFrame(format!(
+            "Audio backing sample count overflow: channel offset {} + {} samples",
+            last_channel_offset, no_samples
         ))
     })?;
 
@@ -1660,20 +1882,84 @@ pub(crate) fn validate_audio_layout(raw: &NDIlib_audio_frame_v3_t) -> Result<Val
         )));
     }
 
-    let format = match raw.FourCC {
-        NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => AudioFormat::FLTP,
-        _ => {
-            return Err(Error::InvalidFrame(format!(
-                "Unknown audio format FourCC: 0x{:08X}",
-                raw.FourCC
-            )))
-        }
+    Ok(ValidatedAudioLayout {
+        format: Some(format),
+        sample_rate: raw.sample_rate,
+        no_channels,
+        no_samples,
+        channel_stride_in_bytes,
+        channel_stride_samples,
+        sample_count,
+    })
+}
+
+fn validate_empty_audio_layout(raw: &NDIlib_audio_frame_v3_t) -> Result<ValidatedAudioLayout> {
+    if !raw.p_data.is_null() {
+        return Err(Error::InvalidFrame(
+            "Zero-length audio frame has non-null data pointer".into(),
+        ));
+    }
+
+    if raw.sample_rate < 0 {
+        return Err(Error::InvalidFrame(format!(
+            "Invalid sample rate: {}",
+            raw.sample_rate
+        )));
+    }
+
+    if raw.no_channels < 0 {
+        return Err(Error::InvalidFrame(format!(
+            "Invalid number of channels: {}",
+            raw.no_channels
+        )));
+    }
+
+    let channel_stride_in_bytes = unsafe { raw.__bindgen_anon_1.channel_stride_in_bytes };
+    if channel_stride_in_bytes != 0 {
+        return Err(Error::InvalidFrame(format!(
+            "Zero-length audio frame has non-zero channel_stride_in_bytes: {}",
+            channel_stride_in_bytes
+        )));
+    }
+
+    let no_source = raw.sample_rate == 0 && raw.no_channels == 0;
+    let query_format = raw.sample_rate > 0 && raw.no_channels > 0;
+    if !no_source && !query_format {
+        return Err(Error::InvalidFrame(format!(
+            "Invalid zero-length audio query state: sample_rate={}, no_channels={}",
+            raw.sample_rate, raw.no_channels
+        )));
+    }
+
+    let format = if no_source && raw.FourCC == 0 {
+        None
+    } else {
+        Some(validate_audio_format(raw.FourCC)?)
     };
+
+    let no_channels = usize::try_from(raw.no_channels).map_err(|_| {
+        Error::InvalidFrame(format!("Invalid no_channels value: {}", raw.no_channels))
+    })?;
 
     Ok(ValidatedAudioLayout {
         format,
-        sample_count,
+        sample_rate: raw.sample_rate,
+        no_channels,
+        no_samples: 0,
+        channel_stride_in_bytes: 0,
+        channel_stride_samples: 0,
+        sample_count: 0,
     })
+}
+
+fn validate_audio_format(fourcc: NDIlib_FourCC_audio_type_e) -> Result<AudioFormat> {
+    match fourcc {
+        NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => Ok(AudioFormat::FLTP),
+        _ => Err(Error::InvalidFrame(format!(
+            "Unknown audio format FourCC: 0x{:08X}",
+            fourcc
+        ))),
+    }
 }
 
 // ============================================================================
@@ -1868,7 +2154,7 @@ impl<'rx> VideoFrameRef<'rx> {
     /// This performs a single memcpy of the frame data and metadata,
     /// allowing the frame to outlive the NDI buffer and be sent across threads.
     pub fn to_owned(&self) -> Result<VideoFrame> {
-        unsafe { VideoFrame::from_raw(self.guard.frame()) }
+        unsafe { VideoFrame::from_raw_validated(self.guard.frame(), self.layout) }
     }
 }
 
@@ -1956,17 +2242,17 @@ impl<'rx> AudioFrameRef<'rx> {
 
     /// Get the sample rate in Hz.
     pub fn sample_rate(&self) -> i32 {
-        self.guard.frame().sample_rate
+        self.layout.sample_rate
     }
 
     /// Get the number of audio channels.
     pub fn num_channels(&self) -> i32 {
-        self.guard.frame().no_channels
+        self.layout.no_channels as i32
     }
 
     /// Get the number of samples per channel.
     pub fn num_samples(&self) -> i32 {
-        self.guard.frame().no_samples
+        self.layout.no_samples as i32
     }
 
     /// Get the timecode.
@@ -1983,12 +2269,14 @@ impl<'rx> AudioFrameRef<'rx> {
     ///
     /// This is guaranteed to be a valid, supported format since it's validated during construction.
     pub fn format(&self) -> AudioFormat {
-        self.layout.format
+        self.layout
+            .format()
+            .expect("validate_audio_layout requires a concrete audio format")
     }
 
     /// Get the channel stride in bytes.
     pub fn channel_stride_in_bytes(&self) -> i32 {
-        unsafe { self.guard.frame().__bindgen_anon_1.channel_stride_in_bytes }
+        self.layout.channel_stride_in_bytes
     }
 
     /// Get the metadata as a `CStr`, if present.
@@ -2024,12 +2312,21 @@ impl<'rx> AudioFrameRef<'rx> {
         }
     }
 
+    /// Get the zero-copy samples for a single channel.
+    ///
+    /// This respects `channel_stride_in_bytes`, so it works for tightly packed
+    /// and strided planar FLTP audio.
+    pub fn channel_data(&self, channel: usize) -> Option<&[f32]> {
+        let range = self.layout.channel_range(channel)?;
+        Some(&self.data()[range])
+    }
+
     /// Convert this borrowed frame to an owned `AudioFrame`.
     ///
     /// This performs a single memcpy of the audio data and metadata,
     /// allowing the frame to outlive the NDI buffer and be sent across threads.
     pub fn to_owned(&self) -> Result<AudioFrame> {
-        AudioFrame::from_raw(*self.guard.frame())
+        AudioFrame::from_raw_validated(*self.guard.frame(), self.layout)
     }
 }
 
@@ -2236,16 +2533,16 @@ mod tests {
     fn test_pixel_format_info_planar_420_odd() {
         // 1921x1081 YV12/I420 (odd width and height)
         // Y: 1921 * 1081 = 2,076,601
-        // U: (1921/2) * ceil(1081/2) = 960 * 541 = 519,360
-        // V: (1921/2) * ceil(1081/2) = 960 * 541 = 519,360
-        // Total: 2,076,601 + 519,360 + 519,360 = 3,115,321
+        // U: ceil(1921/2) * ceil(1081/2) = 961 * 541 = 519,901
+        // V: ceil(1921/2) * ceil(1081/2) = 961 * 541 = 519,901
+        // Total: 2,076,601 + 519,901 + 519,901 = 3,116,403
         let y_stride = 1921;
 
         let len = PixelFormat::YV12.info().buffer_len(y_stride, 1081);
-        assert_eq!(len, 3_115_321, "YV12 1921x1081 (odd dimensions)");
+        assert_eq!(len, 3_116_403, "YV12 1921x1081 (odd dimensions)");
 
         let len = PixelFormat::I420.info().buffer_len(y_stride, 1081);
-        assert_eq!(len, 3_115_321, "I420 1921x1081 (odd dimensions)");
+        assert_eq!(len, 3_116_403, "I420 1921x1081 (odd dimensions)");
     }
 
     /// Test PixelFormatInfo for semi-planar NV12 with even dimensions
@@ -2362,22 +2659,17 @@ mod tests {
         assert_eq!(frame.data.len(), 3_110_400, "NV12 1920x1080 buffer size");
     }
 
-    /// Test VideoFrame builder with planar formats and odd dimensions
+    /// Test VideoFrame builder rejects planar formats with odd dimensions
     #[test]
     fn test_videoframe_builder_planar_odd() {
-        let frame = VideoFrame::builder()
+        let result = VideoFrame::builder()
             .resolution(1921, 1081)
             .pixel_format(PixelFormat::I420)
-            .build()
-            .expect("Builder should succeed");
+            .build();
 
-        assert_eq!(frame.width, 1921);
-        assert_eq!(frame.height, 1081);
-        assert_eq!(frame.pixel_format, PixelFormat::I420);
-        assert_eq!(
-            frame.data.len(),
-            3_115_321,
-            "I420 1921x1081 buffer size with ceiling division"
+        assert!(
+            matches!(result, Err(Error::InvalidFrame(_))),
+            "Planar 4:2:0 odd dimensions should be rejected"
         );
     }
 
@@ -2447,16 +2739,15 @@ mod tests {
         );
     }
 
-    /// Test VideoFrame::from_raw with synthetic I420 frame (odd dimensions)
+    /// Test VideoFrame::from_raw rejects synthetic I420 frame with odd dimensions
     #[test]
     fn test_videoframe_from_raw_i420_odd() {
         let width = 1921;
         let height = 1081;
         let y_stride = 1921;
-        let expected_size = 3_115_321; // Y + U + V with ceiling division
+        let expected_size = 3_116_403; // Y + U + V with ceiling division
 
         let mut data = vec![0u8; expected_size];
-        data[expected_size - 1] = 0xAA;
 
         let c_frame = NDIlib_video_frame_v2_t {
             xres: width,
@@ -2475,14 +2766,11 @@ mod tests {
             timestamp: 0,
         };
 
-        let frame = unsafe { VideoFrame::from_raw(&c_frame) }.expect("from_raw should succeed");
-
-        assert_eq!(
-            frame.data.len(),
-            expected_size,
-            "I420 odd dimensions: full buffer copied"
+        let result = unsafe { VideoFrame::from_raw(&c_frame) };
+        assert!(
+            matches!(result, Err(Error::InvalidFrame(_))),
+            "Planar 4:2:0 odd dimensions should be rejected"
         );
-        assert_eq!(frame.data[expected_size - 1], 0xAA, "Last byte copied");
     }
 
     /// Regression test: VideoFrame::from_raw with packed format should be unchanged
@@ -2766,10 +3054,9 @@ mod tests {
     /// Test that audio frames with overflow in checked_mul are rejected
     #[test]
     fn test_audio_overflow_checked_mul() {
-        // Use no_samples = i32::MAX and no_channels = 2 to trigger overflow
-        // When multiplying i32::MAX * 2, the result overflows usize::checked_mul
-        let no_samples = i32::MAX;
-        let no_channels = 2;
+        // Use an extreme channel count to exceed the maximum backing buffer size.
+        let no_samples = 1024;
+        let no_channels = i32::MAX;
         let mut dummy_data = vec![0f32; 1024]; // Small buffer, won't be used due to guard
 
         let raw = NDIlib_audio_frame_v3_t {
@@ -2780,7 +3067,7 @@ mod tests {
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: dummy_data.as_mut_ptr() as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: no_samples * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 0,
@@ -2821,7 +3108,7 @@ mod tests {
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: data.as_mut_ptr() as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: no_samples * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 67890,
@@ -2994,6 +3281,58 @@ mod tests {
         }
     }
 
+    /// Test validate_video_layout rejects strides smaller than one row.
+    #[test]
+    fn test_validate_video_layout_rejects_short_stride() {
+        let mut data = vec![0u8; 1024];
+
+        let raw = NDIlib_video_frame_v2_t {
+            xres: 1920,
+            yres: 1080,
+            FourCC: PixelFormat::BGRA.into(),
+            frame_rate_N: 60,
+            frame_rate_D: 1,
+            picture_aspect_ratio: 16.0 / 9.0,
+            frame_format_type: ScanType::Progressive.into(),
+            timecode: 0,
+            p_data: data.as_mut_ptr(),
+            __bindgen_anon_1: NDIlib_video_frame_v2_t__bindgen_ty_1 {
+                line_stride_in_bytes: 1919 * 4,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let result = validate_video_layout(&raw);
+        assert!(matches!(result, Err(Error::InvalidFrame(_))));
+    }
+
+    /// Test validate_video_layout rejects odd dimensions for planar 4:2:0.
+    #[test]
+    fn test_validate_video_layout_rejects_planar_odd_dimensions() {
+        let mut data = vec![0u8; 4096];
+
+        let raw = NDIlib_video_frame_v2_t {
+            xres: 641,
+            yres: 480,
+            FourCC: PixelFormat::I420.into(),
+            frame_rate_N: 60,
+            frame_rate_D: 1,
+            picture_aspect_ratio: 4.0 / 3.0,
+            frame_format_type: ScanType::Progressive.into(),
+            timecode: 0,
+            p_data: data.as_mut_ptr(),
+            __bindgen_anon_1: NDIlib_video_frame_v2_t__bindgen_ty_1 {
+                line_stride_in_bytes: 642,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let result = validate_video_layout(&raw);
+        assert!(matches!(result, Err(Error::InvalidFrame(_))));
+    }
+
     /// Test validate_video_layout rejects negative dimensions
     #[test]
     fn test_validate_video_layout_negative_dimensions() {
@@ -3086,7 +3425,7 @@ mod tests {
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: data.as_mut_ptr() as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: no_samples * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 0,
@@ -3096,8 +3435,118 @@ mod tests {
         assert!(result.is_ok(), "Should validate valid audio frame");
 
         let layout = result.unwrap();
-        assert_eq!(layout.format, AudioFormat::FLTP);
+        assert_eq!(layout.format, Some(AudioFormat::FLTP));
         assert_eq!(layout.sample_count, sample_count);
+    }
+
+    /// Test validate_audio_layout supports strided planar FLTP audio.
+    #[test]
+    fn test_validate_audio_layout_strided_planar() {
+        let no_samples = 4;
+        let no_channels = 2;
+        let stride_samples = 6;
+        let backing_samples = (stride_samples + no_samples) as usize;
+        let mut data = vec![0.0f32; backing_samples];
+
+        let raw = NDIlib_audio_frame_v3_t {
+            sample_rate: 48000,
+            no_channels,
+            no_samples,
+            timecode: 0,
+            FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
+            p_data: data.as_mut_ptr() as *mut u8,
+            __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
+                channel_stride_in_bytes: stride_samples * 4,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let layout = validate_audio_layout(&raw).expect("strided FLTP should validate");
+        assert_eq!(layout.sample_count, backing_samples);
+        assert_eq!(layout.channel_stride_samples, stride_samples as usize);
+        assert_eq!(layout.channel_range(1), Some(6..10));
+    }
+
+    /// Test validate_audio_layout_allow_empty accepts the documented no-source query state.
+    #[test]
+    fn test_validate_audio_layout_empty_query_no_source() {
+        let raw = NDIlib_audio_frame_v3_t::default();
+
+        let layout =
+            validate_audio_layout_allow_empty(&raw).expect("all-zero query state should validate");
+        assert!(layout.is_empty());
+        assert_eq!(layout.format(), None);
+        assert_eq!(layout.sample_count, 0);
+    }
+
+    /// Test validate_audio_layout_allow_empty accepts source-format query without samples.
+    #[test]
+    fn test_validate_audio_layout_empty_query_with_source_format() {
+        let raw = NDIlib_audio_frame_v3_t {
+            sample_rate: 48000,
+            no_channels: 2,
+            no_samples: 0,
+            timecode: 0,
+            FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
+            p_data: ptr::null_mut(),
+            __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
+                channel_stride_in_bytes: 0,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let layout = validate_audio_layout_allow_empty(&raw)
+            .expect("query source format should validate without samples");
+        assert!(layout.is_empty());
+        assert_eq!(layout.format(), Some(AudioFormat::FLTP));
+        assert_eq!(layout.sample_rate, 48000);
+        assert_eq!(layout.no_channels, 2);
+    }
+
+    /// Test empty audio validation rejects partial query/no-source states.
+    #[test]
+    fn test_validate_audio_layout_rejects_partial_empty_query() {
+        let raw = NDIlib_audio_frame_v3_t {
+            sample_rate: 48000,
+            no_channels: 0,
+            no_samples: 0,
+            timecode: 0,
+            FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
+            p_data: ptr::null_mut(),
+            __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
+                channel_stride_in_bytes: 0,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let result = validate_audio_layout_allow_empty(&raw);
+        assert!(matches!(result, Err(Error::InvalidFrame(_))));
+    }
+
+    /// Test validate_audio_layout rejects invalid channel stride.
+    #[test]
+    fn test_validate_audio_layout_rejects_invalid_channel_stride() {
+        let mut data = vec![0.0f32; 2048];
+
+        let raw = NDIlib_audio_frame_v3_t {
+            sample_rate: 48000,
+            no_channels: 2,
+            no_samples: 1024,
+            timecode: 0,
+            FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
+            p_data: data.as_mut_ptr() as *mut u8,
+            __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
+                channel_stride_in_bytes: 1024 * 4 - 4,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let result = validate_audio_layout(&raw);
+        assert!(matches!(result, Err(Error::InvalidFrame(_))));
     }
 
     /// Test validate_audio_layout rejects null data pointer
@@ -3111,7 +3560,7 @@ mod tests {
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: ptr::null_mut(),
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: 1024 * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 0,
@@ -3143,7 +3592,7 @@ mod tests {
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: data.as_mut_ptr() as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: 1024 * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 0,
@@ -3169,13 +3618,13 @@ mod tests {
 
         let raw = NDIlib_audio_frame_v3_t {
             sample_rate: 48000,
-            no_channels: 2,
-            no_samples: i32::MAX, // Will overflow when multiplied by channels
+            no_channels: i32::MAX,
+            no_samples: 1024,
             timecode: 0,
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: data.as_mut_ptr() as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: 1024 * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 0,
@@ -3298,7 +3747,7 @@ mod tests {
             FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
             p_data: data.as_ptr() as *mut u8,
             __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
-                channel_stride_in_bytes: 0,
+                channel_stride_in_bytes: no_samples * 4,
             },
             p_metadata: ptr::null(),
             timestamp: 67890,

--- a/src/framesync.rs
+++ b/src/framesync.rs
@@ -41,8 +41,11 @@
 //! # Example
 //!
 //! ```no_run
-//! use grafton_ndi::{NDI, Finder, FinderOptions, ReceiverOptions, Receiver, FrameSync, ScanType};
-//! use std::time::Duration;
+//! use grafton_ndi::{
+//!     NDI, Finder, FinderOptions, ReceiverOptions, Receiver, FrameSync,
+//!     FrameSyncAudioRequest, ScanType,
+//! };
+//! use std::{num::NonZeroI32, time::Duration};
 //!
 //! fn main() -> Result<(), grafton_ndi::Error> {
 //!     let ndi = NDI::new()?;
@@ -57,26 +60,127 @@
 //!     let framesync = FrameSync::new(receiver)?;
 //!
 //!     // Capture video synced to your output timing
-//!     if let Some(frame) = framesync.capture_video(ScanType::Progressive) {
+//!     if let Some(frame) = framesync.capture_video(ScanType::Progressive)? {
 //!         println!("{}x{} frame", frame.width(), frame.height());
 //!     }
 //!
 //!     // Capture audio at your sound card's rate
-//!     let audio = framesync.capture_audio(48000, 2, 1024);
+//!     let audio = framesync.capture_audio(FrameSyncAudioRequest::Capture {
+//!         sample_rate: Some(NonZeroI32::new(48_000).unwrap()),
+//!         channels: Some(NonZeroI32::new(2).unwrap()),
+//!         samples: NonZeroI32::new(1_024).unwrap(),
+//!     })?;
 //!     println!("{} audio samples", audio.num_samples());
 //!
 //!     Ok(())
 //! }
 //! ```
 
-use std::{ffi::CStr, fmt, mem::ManuallyDrop, ptr, slice};
+use std::{ffi::CStr, fmt, marker::PhantomData, mem::ManuallyDrop, num::NonZeroI32, ptr, slice};
 
 use crate::{
-    frames::{AudioFormat, AudioFrame, LineStrideOrSize, PixelFormat, ScanType, VideoFrame},
+    frames::{
+        validate_audio_layout, validate_audio_layout_allow_empty, validate_video_layout,
+        AudioFormat, AudioFrame, LineStrideOrSize, PixelFormat, ScanType, ValidatedAudioLayout,
+        ValidatedVideoLayout, VideoFrame,
+    },
     ndi_lib::*,
     receiver::Receiver,
     Error, Result,
 };
+
+/// Explicit audio operation for [`FrameSync::capture_audio`].
+///
+/// FrameSync audio has two distinct SDK modes:
+/// - [`QueryInput`](Self::QueryInput) asks the SDK for the current input audio
+///   format without requesting samples.
+/// - [`Capture`](Self::Capture) asks the SDK for a positive number of samples,
+///   optionally using the source sample rate and/or source channel count.
+///
+/// `None` for `sample_rate` or `channels` maps to the SDK's `0` value, meaning
+/// "use the current source value". The `samples` field must be positive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameSyncAudioRequest {
+    /// Query the current incoming audio format without requesting sample data.
+    QueryInput,
+    /// Capture audio samples with optional source-derived output parameters.
+    Capture {
+        /// Requested output sample rate. `None` uses the current source rate.
+        sample_rate: Option<NonZeroI32>,
+        /// Requested output channel count. `None` uses the current source count.
+        channels: Option<NonZeroI32>,
+        /// Number of samples to capture per channel.
+        samples: NonZeroI32,
+    },
+}
+
+impl FrameSyncAudioRequest {
+    /// Capture samples using the source sample rate and source channel count.
+    pub fn capture(samples: NonZeroI32) -> Self {
+        Self::Capture {
+            sample_rate: None,
+            channels: None,
+            samples,
+        }
+    }
+
+    /// Capture samples with explicit optional sample-rate and channel requests.
+    pub fn capture_with(
+        sample_rate: Option<NonZeroI32>,
+        channels: Option<NonZeroI32>,
+        samples: NonZeroI32,
+    ) -> Self {
+        Self::Capture {
+            sample_rate,
+            channels,
+            samples,
+        }
+    }
+
+    fn to_raw(self) -> Result<FrameSyncAudioRawRequest> {
+        match self {
+            Self::QueryInput => Ok(FrameSyncAudioRawRequest {
+                sample_rate: 0,
+                channels: 0,
+                samples: 0,
+                query_input: true,
+            }),
+            Self::Capture {
+                sample_rate,
+                channels,
+                samples,
+            } => Ok(FrameSyncAudioRawRequest {
+                sample_rate: positive_optional_i32("sample_rate", sample_rate)?,
+                channels: positive_optional_i32("channels", channels)?,
+                samples: positive_i32("samples", samples)?,
+                query_input: false,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FrameSyncAudioRawRequest {
+    sample_rate: i32,
+    channels: i32,
+    samples: i32,
+    query_input: bool,
+}
+
+fn positive_optional_i32(field: &str, value: Option<NonZeroI32>) -> Result<i32> {
+    value.map_or(Ok(0), |value| positive_i32(field, value))
+}
+
+fn positive_i32(field: &str, value: NonZeroI32) -> Result<i32> {
+    let value = value.get();
+    if value > 0 {
+        Ok(value)
+    } else {
+        Err(Error::InvalidConfiguration(format!(
+            "FrameSync audio {field} must be positive, got {value}"
+        )))
+    }
+}
 
 /// Frame synchronizer for clock-corrected capture.
 ///
@@ -99,7 +203,8 @@ use crate::{
 /// # Example
 ///
 /// ```no_run
-/// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, FrameSync, Source, SourceAddress, ScanType};
+/// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, FrameSync, FrameSyncAudioRequest, Source, SourceAddress, ScanType};
+/// # use std::num::NonZeroI32;
 /// # fn main() -> Result<(), grafton_ndi::Error> {
 /// # let ndi = NDI::new()?;
 /// # let source = Source { name: "Test".into(), address: SourceAddress::None };
@@ -108,12 +213,16 @@ use crate::{
 /// let framesync = FrameSync::new(receiver)?;
 ///
 /// // FrameSync captures always return immediately
-/// if let Some(video) = framesync.capture_video(ScanType::Progressive) {
+/// if let Some(video) = framesync.capture_video(ScanType::Progressive)? {
 ///     println!("Video: {}x{}", video.width(), video.height());
 /// }
 ///
-/// // Audio capture always returns data (silence if none available)
-/// let audio = framesync.capture_audio(48000, 2, 1024);
+/// // Audio capture uses an explicit request; None means "use source value".
+/// let audio = framesync.capture_audio(FrameSyncAudioRequest::Capture {
+///     sample_rate: Some(NonZeroI32::new(48_000).unwrap()),
+///     channels: Some(NonZeroI32::new(2).unwrap()),
+///     samples: NonZeroI32::new(1_024).unwrap(),
+/// })?;
 /// println!("Audio: {} samples", audio.num_samples());
 /// # Ok(())
 /// # }
@@ -198,8 +307,9 @@ impl FrameSync {
     ///
     /// # Returns
     ///
-    /// * `Some(FrameSyncVideoRef)` - A zero-copy reference to the captured frame
-    /// * `None` - No video has been received yet (before first frame arrives)
+    /// * `Ok(Some(FrameSyncVideoRef))` - A validated zero-copy reference to the captured frame
+    /// * `Ok(None)` - The SDK returned the documented all-zero "no video yet" state
+    /// * `Err(Error::InvalidFrame(_))` - The SDK returned non-empty malformed metadata
     ///
     /// # Example
     ///
@@ -214,7 +324,7 @@ impl FrameSync {
     ///
     /// // Capture loop - call at your output frame rate
     /// loop {
-    ///     if let Some(frame) = framesync.capture_video(ScanType::Progressive) {
+    ///     if let Some(frame) = framesync.capture_video(ScanType::Progressive)? {
     ///         // Process/display frame
     ///         println!("{}x{} @ {}/{} fps",
     ///             frame.width(), frame.height(),
@@ -228,7 +338,7 @@ impl FrameSync {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn capture_video(&self, field_type: ScanType) -> Option<FrameSyncVideoRef<'_>> {
+    pub fn capture_video(&self, field_type: ScanType) -> Result<Option<FrameSyncVideoRef<'_>>> {
         let mut frame = NDIlib_video_frame_v2_t::default();
 
         unsafe {
@@ -236,22 +346,14 @@ impl FrameSync {
         }
 
         // Per SDK docs: Returns zeroed struct if no video received yet
-        if frame.p_data.is_null() || frame.xres == 0 || frame.yres == 0 {
-            return None;
+        if is_framesync_video_empty(&frame) {
+            return Ok(None);
         }
 
-        // Try to parse the pixel format - return None if unknown
-        #[allow(clippy::unnecessary_cast)]
-        let pixel_format = match PixelFormat::try_from(frame.FourCC as u32) {
-            Ok(fmt) => fmt,
-            Err(_) => return None,
-        };
+        let guard = unsafe { FrameSyncVideoGuard::new(self.instance, frame) };
+        let frame = unsafe { FrameSyncVideoRef::new(guard)? };
 
-        Some(FrameSyncVideoRef {
-            framesync: self,
-            frame,
-            pixel_format,
-        })
+        Ok(Some(frame))
     }
 
     /// Capture video and convert to an owned frame.
@@ -265,38 +367,51 @@ impl FrameSync {
     ///
     /// # Returns
     ///
-    /// * `Some(Ok(VideoFrame))` - An owned copy of the captured frame
-    /// * `Some(Err(_))` - Frame was captured but conversion failed
-    /// * `None` - No video has been received yet
-    pub fn capture_video_owned(&self, field_type: ScanType) -> Option<Result<VideoFrame>> {
-        self.capture_video(field_type).map(|frame| frame.to_owned())
+    /// * `Ok(Some(VideoFrame))` - An owned copy of the captured frame
+    /// * `Ok(None)` - No video has been received yet
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the SDK returns non-empty malformed frame metadata.
+    pub fn capture_video_owned(&self, field_type: ScanType) -> Result<Option<VideoFrame>> {
+        self.capture_video(field_type)?
+            .map(|frame| frame.to_owned())
+            .transpose()
     }
 
     /// Capture audio with dynamic resampling.
     ///
-    /// This function always returns immediately, inserting silence if no audio
-    /// is available. The NDI SDK automatically resamples the incoming audio to
-    /// match the requested sample rate, channel count, and sample count.
+    /// This function always returns immediately. Capture requests ask the NDI
+    /// SDK to resample incoming audio to match the requested sample rate,
+    /// channel count, and sample count. Query requests return the current input
+    /// format without requesting samples.
     ///
     /// Call this at the rate you need audio - the SDK will adapt the incoming
     /// signal to match your output timing using dynamic audio sampling.
     ///
     /// # Arguments
     ///
-    /// * `sample_rate` - Desired output sample rate (e.g., 48000)
-    /// * `channels` - Desired number of output channels (e.g., 2 for stereo)
-    /// * `samples` - Number of samples to capture per channel
+    /// * `request` - Explicit capture or query operation. For capture requests,
+    ///   `None` sample rate or channels means "use the current source value".
     ///
     /// # Querying Input Format
     ///
-    /// Pass 0 for `sample_rate` and `channels` to query the current input format
-    /// without capturing samples. The returned frame will contain the input's
-    /// sample rate and channel count (or zeros if no audio received yet).
+    /// Use [`FrameSyncAudioRequest::QueryInput`] to query the current input
+    /// format without capturing samples. The returned frame contains the
+    /// input's sample rate and channel count, or a validated empty no-source
+    /// state when no audio format has been received yet.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidFrame`] if the SDK returns malformed audio
+    /// metadata, or [`Error::InvalidConfiguration`] if the request contains a
+    /// negative `NonZeroI32` value.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, FrameSync, Source, SourceAddress};
+    /// # use grafton_ndi::{NDI, ReceiverOptions, Receiver, FrameSync, FrameSyncAudioRequest, Source, SourceAddress};
+    /// # use std::num::NonZeroI32;
     /// # fn main() -> Result<(), grafton_ndi::Error> {
     /// # let ndi = NDI::new()?;
     /// # let source = Source { name: "Test".into(), address: SourceAddress::None };
@@ -305,16 +420,22 @@ impl FrameSync {
     /// let framesync = FrameSync::new(receiver)?;
     ///
     /// // Audio callback - called by sound card at its rate
+    /// let request = FrameSyncAudioRequest::Capture {
+    ///     sample_rate: Some(NonZeroI32::new(48_000).unwrap()),
+    ///     channels: Some(NonZeroI32::new(2).unwrap()),
+    ///     samples: NonZeroI32::new(1_024).unwrap(),
+    /// };
+    ///
     /// loop {
     ///     // Request 1024 stereo samples at 48kHz
-    ///     let audio = framesync.capture_audio(48000, 2, 1024);
+    ///     let audio = framesync.capture_audio(request)?;
     ///
     ///     // Process audio samples
     ///     let samples = audio.data();
     ///     println!("Got {} samples", samples.len());
     ///
-    ///     // Check if we're receiving audio or just silence
-    ///     if audio.sample_rate() == 0 {
+    ///     // Check for a validated query/no-source empty state
+    ///     if audio.is_empty() {
     ///         println!("No audio source yet");
     ///     }
     ///     # break;
@@ -322,52 +443,43 @@ impl FrameSync {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn capture_audio(
-        &self,
-        sample_rate: i32,
-        channels: i32,
-        samples: i32,
-    ) -> FrameSyncAudioRef<'_> {
+    pub fn capture_audio(&self, request: FrameSyncAudioRequest) -> Result<FrameSyncAudioRef<'_>> {
+        let request = request.to_raw()?;
         let mut frame = NDIlib_audio_frame_v3_t::default();
 
         unsafe {
             NDIlib_framesync_capture_audio_v2(
                 self.instance,
                 &mut frame,
-                sample_rate,
-                channels,
-                samples,
+                request.sample_rate,
+                request.channels,
+                request.samples,
             );
         }
 
-        FrameSyncAudioRef {
-            framesync: self,
-            frame,
-        }
+        let guard = unsafe { FrameSyncAudioGuard::new(self.instance, frame) };
+        unsafe { FrameSyncAudioRef::new(guard, request.query_input) }
     }
 
     /// Capture audio and convert to an owned frame.
     ///
     /// This is a convenience method that captures audio and immediately converts
-    /// it to an owned [`AudioFrame`] that can be sent across threads.
+    /// it to an owned [`AudioFrame`] that can be sent across threads. Query or
+    /// no-source states that contain no sample buffer return `Ok(None)`.
     ///
     /// # Arguments
     ///
-    /// * `sample_rate` - Desired output sample rate
-    /// * `channels` - Desired number of output channels
-    /// * `samples` - Number of samples to capture per channel
+    /// * `request` - Explicit capture or query operation.
     ///
     /// # Errors
     ///
-    /// Returns an error if the frame conversion fails (e.g., invalid format).
+    /// Returns an error if the request is invalid or the SDK returns malformed
+    /// audio metadata.
     pub fn capture_audio_owned(
         &self,
-        sample_rate: i32,
-        channels: i32,
-        samples: i32,
-    ) -> Result<AudioFrame> {
-        self.capture_audio(sample_rate, channels, samples)
-            .to_owned()
+        request: FrameSyncAudioRequest,
+    ) -> Result<Option<AudioFrame>> {
+        self.capture_audio(request)?.to_owned()
     }
 
     /// Query the current audio queue depth.
@@ -430,6 +542,85 @@ impl fmt::Debug for FrameSync {
     }
 }
 
+pub(crate) fn is_framesync_video_empty(frame: &NDIlib_video_frame_v2_t) -> bool {
+    frame.xres == 0
+        && frame.yres == 0
+        && frame.FourCC == 0
+        && frame.frame_rate_N == 0
+        && frame.frame_rate_D == 0
+        && frame.picture_aspect_ratio == 0.0
+        && frame.frame_format_type == 0
+        && frame.timecode == 0
+        && frame.p_data.is_null()
+        && unsafe { frame.__bindgen_anon_1.data_size_in_bytes } == 0
+        && frame.p_metadata.is_null()
+        && frame.timestamp == 0
+}
+
+struct FrameSyncVideoGuard<'fs> {
+    instance: NDIlib_framesync_instance_t,
+    frame: NDIlib_video_frame_v2_t,
+    _owner: PhantomData<&'fs FrameSync>,
+}
+
+impl<'fs> FrameSyncVideoGuard<'fs> {
+    unsafe fn new(instance: NDIlib_framesync_instance_t, frame: NDIlib_video_frame_v2_t) -> Self {
+        Self {
+            instance,
+            frame,
+            _owner: PhantomData,
+        }
+    }
+
+    fn frame(&self) -> &NDIlib_video_frame_v2_t {
+        &self.frame
+    }
+}
+
+impl Drop for FrameSyncVideoGuard<'_> {
+    fn drop(&mut self) {
+        if self.instance.is_null() {
+            return;
+        }
+
+        unsafe {
+            NDIlib_framesync_free_video(self.instance, &mut self.frame);
+        }
+    }
+}
+
+struct FrameSyncAudioGuard<'fs> {
+    instance: NDIlib_framesync_instance_t,
+    frame: NDIlib_audio_frame_v3_t,
+    _owner: PhantomData<&'fs FrameSync>,
+}
+
+impl<'fs> FrameSyncAudioGuard<'fs> {
+    unsafe fn new(instance: NDIlib_framesync_instance_t, frame: NDIlib_audio_frame_v3_t) -> Self {
+        Self {
+            instance,
+            frame,
+            _owner: PhantomData,
+        }
+    }
+
+    fn frame(&self) -> &NDIlib_audio_frame_v3_t {
+        &self.frame
+    }
+}
+
+impl Drop for FrameSyncAudioGuard<'_> {
+    fn drop(&mut self) {
+        if self.instance.is_null() {
+            return;
+        }
+
+        unsafe {
+            NDIlib_framesync_free_audio_v2(self.instance, &mut self.frame);
+        }
+    }
+}
+
 /// A zero-copy borrowed video frame from FrameSync capture.
 ///
 /// This type wraps a frame captured via [`FrameSync::capture_video`], providing
@@ -455,7 +646,7 @@ impl fmt::Debug for FrameSync {
 /// # let receiver = Receiver::new(&ndi, &options)?;
 /// let framesync = FrameSync::new(receiver)?;
 ///
-/// if let Some(frame_ref) = framesync.capture_video(ScanType::Progressive) {
+/// if let Some(frame_ref) = framesync.capture_video(ScanType::Progressive)? {
 ///     let owned = frame_ref.to_owned()?;
 ///     // owned can now be sent across threads
 /// }
@@ -463,75 +654,75 @@ impl fmt::Debug for FrameSync {
 /// # }
 /// ```
 pub struct FrameSyncVideoRef<'fs> {
-    framesync: &'fs FrameSync,
-    frame: NDIlib_video_frame_v2_t,
-    pixel_format: PixelFormat,
+    guard: FrameSyncVideoGuard<'fs>,
+    layout: ValidatedVideoLayout,
 }
 
 impl<'fs> FrameSyncVideoRef<'fs> {
+    unsafe fn new(guard: FrameSyncVideoGuard<'fs>) -> Result<Self> {
+        let layout = validate_video_layout(guard.frame())?;
+
+        Ok(Self { guard, layout })
+    }
+
     /// Get the frame width in pixels.
     pub fn width(&self) -> i32 {
-        self.frame.xres
+        self.guard.frame().xres
     }
 
     /// Get the frame height in pixels.
     pub fn height(&self) -> i32 {
-        self.frame.yres
+        self.guard.frame().yres
     }
 
     /// Get the pixel format (FourCC code).
     pub fn pixel_format(&self) -> PixelFormat {
-        self.pixel_format
+        self.layout.pixel_format
     }
 
     /// Get the frame rate numerator.
     pub fn frame_rate_n(&self) -> i32 {
-        self.frame.frame_rate_N
+        self.guard.frame().frame_rate_N
     }
 
     /// Get the frame rate denominator.
     pub fn frame_rate_d(&self) -> i32 {
-        self.frame.frame_rate_D
+        self.guard.frame().frame_rate_D
     }
 
     /// Get the picture aspect ratio.
     pub fn picture_aspect_ratio(&self) -> f32 {
-        self.frame.picture_aspect_ratio
+        self.guard.frame().picture_aspect_ratio
     }
 
     /// Get the scan type (progressive, interlaced, etc.).
     pub fn scan_type(&self) -> ScanType {
         #[allow(clippy::unnecessary_cast)]
-        ScanType::try_from(self.frame.frame_format_type as u32).unwrap_or(ScanType::Progressive)
+        ScanType::try_from(self.guard.frame().frame_format_type as u32)
+            .unwrap_or(ScanType::Progressive)
     }
 
     /// Get the timecode.
     pub fn timecode(&self) -> i64 {
-        self.frame.timecode
+        self.guard.frame().timecode
     }
 
     /// Get the timestamp.
     pub fn timestamp(&self) -> i64 {
-        self.frame.timestamp
+        self.guard.frame().timestamp
     }
 
     /// Get the line stride or data size.
     pub fn line_stride_or_size(&self) -> LineStrideOrSize {
-        if self.pixel_format.is_uncompressed() {
-            let line_stride = unsafe { self.frame.__bindgen_anon_1.line_stride_in_bytes };
-            LineStrideOrSize::LineStrideBytes(line_stride)
-        } else {
-            let data_size = unsafe { self.frame.__bindgen_anon_1.data_size_in_bytes };
-            LineStrideOrSize::DataSizeBytes(data_size)
-        }
+        self.layout.line_stride_or_size
     }
 
     /// Get the metadata as a `CStr`, if present.
     pub fn metadata(&self) -> Option<&CStr> {
-        if self.frame.p_metadata.is_null() {
+        if self.guard.frame().p_metadata.is_null() {
             None
         } else {
-            Some(unsafe { CStr::from_ptr(self.frame.p_metadata) })
+            Some(unsafe { CStr::from_ptr(self.guard.frame().p_metadata) })
         }
     }
 
@@ -540,33 +731,7 @@ impl<'fs> FrameSyncVideoRef<'fs> {
     /// This returns a slice directly into the NDI SDK's buffer.
     /// No allocation or memcpy is performed.
     pub fn data(&self) -> &[u8] {
-        if self.frame.p_data.is_null() {
-            return &[];
-        }
-
-        let data_size = if self.pixel_format.is_uncompressed() {
-            let line_stride = unsafe { self.frame.__bindgen_anon_1.line_stride_in_bytes };
-            if line_stride > 0 && self.frame.yres > 0 && self.frame.xres > 0 {
-                self.pixel_format
-                    .info()
-                    .buffer_len(line_stride, self.frame.yres)
-            } else {
-                0
-            }
-        } else {
-            let size = unsafe { self.frame.__bindgen_anon_1.data_size_in_bytes };
-            if size > 0 {
-                size as usize
-            } else {
-                0
-            }
-        };
-
-        if data_size == 0 {
-            &[]
-        } else {
-            unsafe { slice::from_raw_parts(self.frame.p_data, data_size) }
-        }
+        unsafe { slice::from_raw_parts(self.guard.frame().p_data, self.layout.data_len_bytes) }
     }
 
     /// Convert this borrowed frame to an owned `VideoFrame`.
@@ -574,15 +739,7 @@ impl<'fs> FrameSyncVideoRef<'fs> {
     /// This performs a single memcpy of the frame data and metadata,
     /// allowing the frame to outlive the NDI buffer and be sent across threads.
     pub fn to_owned(&self) -> Result<VideoFrame> {
-        unsafe { VideoFrame::from_raw(&self.frame) }
-    }
-}
-
-impl Drop for FrameSyncVideoRef<'_> {
-    fn drop(&mut self) {
-        unsafe {
-            NDIlib_framesync_free_video(self.framesync.instance, &mut self.frame);
-        }
+        unsafe { VideoFrame::from_raw_validated(self.guard.frame(), self.layout) }
     }
 }
 
@@ -617,65 +774,84 @@ impl fmt::Debug for FrameSyncVideoRef<'_> {
 /// - RAII lifetime: Exactly one free per frame, enforced at compile time
 /// - Not `Send`: Prevents accidental cross-thread use of FFI buffers
 ///
-/// # Always Returns Data
+/// # Empty Query State
 ///
-/// Unlike raw receiver capture, FrameSync audio capture *always* returns data.
-/// If no audio is available, the SDK inserts silence. Check `sample_rate() == 0`
-/// to detect when no source audio has been received yet.
+/// Query requests can produce a validated zero-length state when no source
+/// audio format is known or when the request did not ask for samples. In that
+/// state [`is_empty`](Self::is_empty) is true and [`data`](Self::data) returns
+/// an empty slice.
 pub struct FrameSyncAudioRef<'fs> {
-    framesync: &'fs FrameSync,
-    frame: NDIlib_audio_frame_v3_t,
+    guard: FrameSyncAudioGuard<'fs>,
+    layout: ValidatedAudioLayout,
 }
 
 impl<'fs> FrameSyncAudioRef<'fs> {
+    unsafe fn new(guard: FrameSyncAudioGuard<'fs>, query_input: bool) -> Result<Self> {
+        let layout = if query_input {
+            if guard.frame().no_samples != 0 {
+                return Err(Error::InvalidFrame(format!(
+                    "FrameSync audio query returned {} samples",
+                    guard.frame().no_samples
+                )));
+            }
+            validate_audio_layout_allow_empty(guard.frame())?
+        } else {
+            validate_audio_layout(guard.frame())?
+        };
+
+        Ok(Self { guard, layout })
+    }
+
     /// Get the sample rate in Hz.
     ///
     /// Returns 0 if no audio source has been received yet.
     pub fn sample_rate(&self) -> i32 {
-        self.frame.sample_rate
+        self.layout.sample_rate
     }
 
     /// Get the number of audio channels.
     ///
     /// Returns 0 if no audio source has been received yet.
     pub fn num_channels(&self) -> i32 {
-        self.frame.no_channels
+        self.layout.no_channels as i32
     }
 
     /// Get the number of samples per channel.
     pub fn num_samples(&self) -> i32 {
-        self.frame.no_samples
+        self.layout.no_samples as i32
+    }
+
+    /// Returns true for a valid query/no-source state with no sample buffer.
+    pub fn is_empty(&self) -> bool {
+        self.layout.is_empty()
     }
 
     /// Get the timecode.
     pub fn timecode(&self) -> i64 {
-        self.frame.timecode
+        self.guard.frame().timecode
     }
 
     /// Get the timestamp.
     pub fn timestamp(&self) -> i64 {
-        self.frame.timestamp
+        self.guard.frame().timestamp
     }
 
     /// Get the audio format (FourCC code).
     pub fn format(&self) -> Option<AudioFormat> {
-        match self.frame.FourCC {
-            NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP => Some(AudioFormat::FLTP),
-            _ => None,
-        }
+        self.layout.format()
     }
 
     /// Get the channel stride in bytes.
     pub fn channel_stride_in_bytes(&self) -> i32 {
-        unsafe { self.frame.__bindgen_anon_1.channel_stride_in_bytes }
+        self.layout.channel_stride_in_bytes
     }
 
     /// Get the metadata as a `CStr`, if present.
     pub fn metadata(&self) -> Option<&CStr> {
-        if self.frame.p_metadata.is_null() {
+        if self.guard.frame().p_metadata.is_null() {
             None
         } else {
-            Some(unsafe { CStr::from_ptr(self.frame.p_metadata) })
+            Some(unsafe { CStr::from_ptr(self.guard.frame().p_metadata) })
         }
     }
 
@@ -685,33 +861,42 @@ impl<'fs> FrameSyncAudioRef<'fs> {
     /// No allocation or memcpy is performed.
     ///
     /// The data is in planar format: all samples for channel 0, then all for
-    /// channel 1, etc.
+    /// channel 1, etc. If the SDK returned strided planar audio, this slice is
+    /// the validated backing span and may include inter-channel padding.
     pub fn data(&self) -> &[f32] {
-        if self.frame.p_data.is_null() {
+        if self.layout.is_empty() {
             return &[];
         }
 
-        let sample_count = (self.frame.no_samples * self.frame.no_channels) as usize;
-        if sample_count == 0 {
-            &[]
-        } else {
-            unsafe { slice::from_raw_parts(self.frame.p_data as *const f32, sample_count) }
+        unsafe {
+            slice::from_raw_parts(
+                self.guard.frame().p_data as *const f32,
+                self.layout.sample_count,
+            )
         }
+    }
+
+    /// Get the zero-copy samples for a single channel.
+    ///
+    /// This respects `channel_stride_in_bytes`, so it works for tightly packed
+    /// and strided planar FLTP audio.
+    pub fn channel_data(&self, channel: usize) -> Option<&[f32]> {
+        let range = self.layout.channel_range(channel)?;
+        Some(&self.data()[range])
     }
 
     /// Convert this borrowed frame to an owned `AudioFrame`.
     ///
     /// This performs a single memcpy of the audio data and metadata,
     /// allowing the frame to outlive the NDI buffer and be sent across threads.
-    pub fn to_owned(&self) -> Result<AudioFrame> {
-        AudioFrame::from_raw(self.frame)
-    }
-}
-
-impl Drop for FrameSyncAudioRef<'_> {
-    fn drop(&mut self) {
-        unsafe {
-            NDIlib_framesync_free_audio_v2(self.framesync.instance, &mut self.frame);
+    ///
+    /// Returns `Ok(None)` for a valid query/no-source state with no sample
+    /// buffer to own.
+    pub fn to_owned(&self) -> Result<Option<AudioFrame>> {
+        if self.layout.is_empty() {
+            Ok(None)
+        } else {
+            AudioFrame::from_raw_validated(*self.guard.frame(), self.layout).map(Some)
         }
     }
 }
@@ -735,6 +920,7 @@ impl fmt::Debug for FrameSyncAudioRef<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ptr;
 
     #[test]
     fn test_framesync_size() {
@@ -757,5 +943,184 @@ mod tests {
         // FrameSyncAudioRef includes a reference and frame struct
         let size = std::mem::size_of::<FrameSyncAudioRef>();
         assert!(size > 0, "FrameSyncAudioRef should have non-zero size");
+    }
+
+    #[test]
+    fn test_video_empty_classifier_accepts_only_all_zero() {
+        let empty = NDIlib_video_frame_v2_t::default();
+        assert!(is_framesync_video_empty(&empty));
+
+        let mut partial = NDIlib_video_frame_v2_t {
+            xres: 1920,
+            ..NDIlib_video_frame_v2_t::default()
+        };
+        assert!(!is_framesync_video_empty(&partial));
+
+        let mut byte = 0u8;
+        partial = NDIlib_video_frame_v2_t {
+            p_data: &mut byte as *mut u8,
+            ..NDIlib_video_frame_v2_t::default()
+        };
+        assert!(!is_framesync_video_empty(&partial));
+    }
+
+    #[test]
+    fn test_framesync_video_ref_uses_validated_layout() {
+        let width = 16;
+        let height = 8;
+        let stride = width * 4;
+        let expected_len = (stride * height) as usize;
+        let mut data = vec![0u8; expected_len];
+
+        let raw = NDIlib_video_frame_v2_t {
+            xres: width,
+            yres: height,
+            FourCC: PixelFormat::BGRA.into(),
+            frame_rate_N: 60,
+            frame_rate_D: 1,
+            picture_aspect_ratio: 16.0 / 9.0,
+            frame_format_type: ScanType::Progressive.into(),
+            timecode: 0,
+            p_data: data.as_mut_ptr(),
+            __bindgen_anon_1: NDIlib_video_frame_v2_t__bindgen_ty_1 {
+                line_stride_in_bytes: stride,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let guard = unsafe { FrameSyncVideoGuard::new(ptr::null_mut(), raw) };
+        let frame = unsafe { FrameSyncVideoRef::new(guard) }.expect("valid video frame");
+
+        assert_eq!(frame.data().len(), expected_len);
+        assert_eq!(
+            frame.line_stride_or_size(),
+            LineStrideOrSize::LineStrideBytes(stride)
+        );
+        assert!(format!("{frame:?}").contains("FrameSyncVideoRef"));
+    }
+
+    #[test]
+    fn test_framesync_video_ref_rejects_partial_empty() {
+        let raw = NDIlib_video_frame_v2_t {
+            xres: 16,
+            yres: 8,
+            FourCC: PixelFormat::BGRA.into(),
+            frame_rate_N: 60,
+            frame_rate_D: 1,
+            picture_aspect_ratio: 16.0 / 9.0,
+            frame_format_type: ScanType::Progressive.into(),
+            timecode: 0,
+            p_data: ptr::null_mut(),
+            __bindgen_anon_1: NDIlib_video_frame_v2_t__bindgen_ty_1 {
+                line_stride_in_bytes: 16 * 4,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let guard = unsafe { FrameSyncVideoGuard::new(ptr::null_mut(), raw) };
+        let result = unsafe { FrameSyncVideoRef::new(guard) };
+        assert!(matches!(result, Err(Error::InvalidFrame(_))));
+    }
+
+    #[test]
+    fn test_framesync_audio_request_rejects_negative_values() {
+        let request = FrameSyncAudioRequest::Capture {
+            sample_rate: Some(NonZeroI32::new(-48_000).unwrap()),
+            channels: Some(NonZeroI32::new(2).unwrap()),
+            samples: NonZeroI32::new(1_024).unwrap(),
+        };
+
+        assert!(matches!(
+            request.to_raw(),
+            Err(Error::InvalidConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn test_framesync_audio_ref_query_no_source_empty() {
+        let raw = NDIlib_audio_frame_v3_t::default();
+        let guard = unsafe { FrameSyncAudioGuard::new(ptr::null_mut(), raw) };
+        let frame = unsafe { FrameSyncAudioRef::new(guard, true) }.expect("empty query frame");
+
+        assert!(frame.is_empty());
+        assert!(frame.data().is_empty());
+        assert_eq!(frame.format(), None);
+        assert!(frame.to_owned().expect("owned conversion").is_none());
+        assert!(format!("{frame:?}").contains("FrameSyncAudioRef"));
+    }
+
+    #[test]
+    fn test_framesync_audio_ref_query_source_format_empty() {
+        let raw = NDIlib_audio_frame_v3_t {
+            sample_rate: 48000,
+            no_channels: 2,
+            no_samples: 0,
+            timecode: 0,
+            FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
+            p_data: ptr::null_mut(),
+            __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
+                channel_stride_in_bytes: 0,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let guard = unsafe { FrameSyncAudioGuard::new(ptr::null_mut(), raw) };
+        let frame = unsafe { FrameSyncAudioRef::new(guard, true) }.expect("query source frame");
+
+        assert!(frame.is_empty());
+        assert_eq!(frame.sample_rate(), 48000);
+        assert_eq!(frame.num_channels(), 2);
+        assert_eq!(frame.format(), Some(AudioFormat::FLTP));
+    }
+
+    #[test]
+    fn test_framesync_audio_ref_capture_rejects_empty() {
+        let raw = NDIlib_audio_frame_v3_t::default();
+        let guard = unsafe { FrameSyncAudioGuard::new(ptr::null_mut(), raw) };
+        let result = unsafe { FrameSyncAudioRef::new(guard, false) };
+
+        assert!(matches!(result, Err(Error::InvalidFrame(_))));
+    }
+
+    #[test]
+    fn test_framesync_audio_ref_supports_strided_planar_data() {
+        let no_samples = 4;
+        let no_channels = 2;
+        let stride_samples = 6;
+        let mut data = vec![0.0f32; 10];
+        data[0..4].copy_from_slice(&[1.0, 2.0, 3.0, 4.0]);
+        data[6..10].copy_from_slice(&[10.0, 20.0, 30.0, 40.0]);
+
+        let raw = NDIlib_audio_frame_v3_t {
+            sample_rate: 48000,
+            no_channels,
+            no_samples,
+            timecode: 0,
+            FourCC: NDIlib_FourCC_audio_type_e_NDIlib_FourCC_audio_type_FLTP,
+            p_data: data.as_mut_ptr() as *mut u8,
+            __bindgen_anon_1: NDIlib_audio_frame_v3_t__bindgen_ty_1 {
+                channel_stride_in_bytes: stride_samples * 4,
+            },
+            p_metadata: ptr::null(),
+            timestamp: 0,
+        };
+
+        let guard = unsafe { FrameSyncAudioGuard::new(ptr::null_mut(), raw) };
+        let frame = unsafe { FrameSyncAudioRef::new(guard, false) }.expect("strided audio frame");
+
+        assert_eq!(frame.data().len(), 10);
+        assert_eq!(frame.channel_data(0), Some(&[1.0, 2.0, 3.0, 4.0][..]));
+        assert_eq!(frame.channel_data(1), Some(&[10.0, 20.0, 30.0, 40.0][..]));
+        assert_eq!(frame.channel_stride_in_bytes(), stride_samples * 4);
+
+        let owned = frame
+            .to_owned()
+            .expect("owned conversion")
+            .expect("samples");
+        assert_eq!(owned.data().len(), 10);
+        assert_eq!(owned.channel_data(1), Some(vec![10.0, 20.0, 30.0, 40.0]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub use {
         LineStrideOrSize, MetadataFrame, MetadataFrameRef, PixelFormat, PixelFormatInfo, ScanType,
         VideoFrame, VideoFrameBuilder, VideoFrameRef,
     },
-    framesync::{FrameSync, FrameSyncAudioRef, FrameSyncVideoRef},
+    framesync::{FrameSync, FrameSyncAudioRef, FrameSyncAudioRequest, FrameSyncVideoRef},
     receiver::{
         ConnectionStats, FrameType, Receiver, ReceiverBandwidth, ReceiverColorFormat,
         ReceiverOptions, ReceiverOptionsBuilder, ReceiverStatus, Tally,


### PR DESCRIPTION
## Summary
- refactor FrameSync video/audio refs to validate SDK-owned buffers before exposing zero-copy slices
- add explicit FrameSyncAudioRequest API and Result-returning FrameSync capture methods
- tighten shared video/audio layout validation, including audio channel stride and query/no-source empty states
- update docs, changelog, exports, and the FrameSync example

Closes #52

## Verification
- cargo fmt
- cargo clippy --all-features
- cargo test --all-features
- cargo check --all-features --examples
- cargo run --example NDIlib_Recv_FrameSync -- 192.168.0.110 --frames 10