### PR TITLE
Make receiver retry capture deadline-aware

### DIFF
--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -7,6 +7,13 @@
 //! use `spawn_blocking` internally to run NDI operations on a thread pool without
 //! blocking the async runtime.
 //!
+//! For reliable `capture_*` methods, the timeout budget starts when the async
+//! method is called. The blocking task receives only the remaining budget when it
+//! begins, so `spawn_blocking` queue delay does not expand the SDK wait budget.
+//! Runtime scheduling can still make the awaited future complete after the timeout;
+//! these wrappers do not use runtime-level cancellation because that would not stop
+//! a queued or running blocking NDI call.
+//!
 //! # Features
 //!
 //! - `tokio` - Enable Tokio runtime support
@@ -42,11 +49,16 @@
 //! # }
 //! ```
 
-use std::{future::Future, marker::PhantomData, sync::Arc, time::Duration};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use crate::{
     frames::{AudioFrame, MetadataFrame, VideoFrame},
-    Receiver, Result,
+    to_ms_checked, Receiver, Result,
 };
 
 #[cfg(feature = "tokio")]
@@ -179,6 +191,15 @@ pub struct AsyncReceiverGeneric<R: SpawnBlocking> {
     _runtime: PhantomData<R>,
 }
 
+fn validated_timeout_start(timeout: Duration) -> Result<Instant> {
+    to_ms_checked(timeout)?;
+    Ok(Instant::now())
+}
+
+fn remaining_timeout(timeout: Duration, start_time: Instant) -> Duration {
+    timeout.saturating_sub(start_time.elapsed())
+}
+
 impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     /// Create a new async receiver wrapper.
     ///
@@ -200,8 +221,10 @@ impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     ///
     /// # Arguments
     ///
-    /// * `timeout` - Total time to wait for a frame.
-    ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
+    /// * `timeout` - Total budget to wait for a frame, starting when this async
+    ///   method is called. Blocking task queue delay is subtracted before the
+    ///   synchronous receiver starts waiting. Must not exceed
+    ///   [`crate::MAX_TIMEOUT`] (~49.7 days).
     ///
     /// # Returns
     ///
@@ -234,8 +257,10 @@ impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     /// # }
     /// ```
     pub async fn capture_video(&self, timeout: Duration) -> Result<VideoFrame> {
+        let start_time = validated_timeout_start(timeout)?;
         let receiver = Arc::clone(&self.inner);
-        R::spawn_blocking(move || receiver.capture_video(timeout)).await?
+        R::spawn_blocking(move || receiver.capture_video(remaining_timeout(timeout, start_time)))
+            .await?
     }
 
     /// Async version of [`Receiver::capture_video_timeout`].
@@ -269,8 +294,10 @@ impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     ///
     /// # Arguments
     ///
-    /// * `timeout` - Total time to wait for a frame.
-    ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
+    /// * `timeout` - Total budget to wait for a frame, starting when this async
+    ///   method is called. Blocking task queue delay is subtracted before the
+    ///   synchronous receiver starts waiting. Must not exceed
+    ///   [`crate::MAX_TIMEOUT`] (~49.7 days).
     ///
     /// # Returns
     ///
@@ -279,8 +306,10 @@ impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     /// * `Err(Error::SpawnFailed)` - The blocking task panicked or was cancelled
     /// * `Err(_)` - An error occurred during capture
     pub async fn capture_audio(&self, timeout: Duration) -> Result<AudioFrame> {
+        let start_time = validated_timeout_start(timeout)?;
         let receiver = Arc::clone(&self.inner);
-        R::spawn_blocking(move || receiver.capture_audio(timeout)).await?
+        R::spawn_blocking(move || receiver.capture_audio(remaining_timeout(timeout, start_time)))
+            .await?
     }
 
     /// Async version of [`Receiver::capture_audio_timeout`].
@@ -310,8 +339,10 @@ impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     ///
     /// # Arguments
     ///
-    /// * `timeout` - Total time to wait for a frame.
-    ///   Must not exceed [`crate::MAX_TIMEOUT`] (~49.7 days).
+    /// * `timeout` - Total budget to wait for a frame, starting when this async
+    ///   method is called. Blocking task queue delay is subtracted before the
+    ///   synchronous receiver starts waiting. Must not exceed
+    ///   [`crate::MAX_TIMEOUT`] (~49.7 days).
     ///
     /// # Returns
     ///
@@ -320,8 +351,10 @@ impl<R: SpawnBlocking> AsyncReceiverGeneric<R> {
     /// * `Err(Error::SpawnFailed)` - The blocking task panicked or was cancelled
     /// * `Err(_)` - An error occurred during capture
     pub async fn capture_metadata(&self, timeout: Duration) -> Result<MetadataFrame> {
+        let start_time = validated_timeout_start(timeout)?;
         let receiver = Arc::clone(&self.inner);
-        R::spawn_blocking(move || receiver.capture_metadata(timeout)).await?
+        R::spawn_blocking(move || receiver.capture_metadata(remaining_timeout(timeout, start_time)))
+            .await?
     }
 
     /// Async version of [`Receiver::capture_metadata_timeout`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,14 +176,13 @@ pub const MAX_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(u3
 /// assert!(result.is_err());
 /// ```
 pub(crate) fn to_ms_checked(d: std::time::Duration) -> Result<u32> {
-    let ms = d.as_millis();
-    if ms > u32::MAX as u128 {
+    if d > MAX_TIMEOUT {
         Err(Error::InvalidConfiguration(format!(
             "timeout {:?} exceeds MAX_TIMEOUT (~49.7 days)",
             d
         )))
     } else {
-        Ok(ms as u32)
+        Ok(d.as_millis() as u32)
     }
 }
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -30,7 +30,11 @@
 //! # }
 //! ```
 
-use std::{ffi::CString, ptr, time::Duration};
+use std::{
+    ffi::CString,
+    ptr,
+    time::{Duration, Instant},
+};
 
 use crate::{
     capture::{capture_audio_raw, capture_metadata_raw, capture_video_raw, CaptureResult},
@@ -78,25 +82,88 @@ impl Default for RetryPolicy {
 ///
 /// - `Ok(T)`: The captured frame on success.
 /// - `Err(Error::FrameTimeout)`: If no frame is captured within the total timeout.
-fn retry_capture<T, F>(timeout: Duration, policy: &RetryPolicy, mut capture_fn: F) -> Result<T>
+fn retry_capture<T, F>(timeout: Duration, policy: &RetryPolicy, capture_fn: F) -> Result<T>
 where
     F: FnMut(Duration) -> Result<Option<T>>,
 {
-    let start_time = std::time::Instant::now();
+    let start_time = Instant::now();
+    retry_capture_with_clock(
+        timeout,
+        policy,
+        capture_fn,
+        || start_time.elapsed(),
+        std::thread::sleep,
+    )
+}
+
+fn retry_capture_with_clock<T, F, E, S>(
+    timeout: Duration,
+    policy: &RetryPolicy,
+    mut capture_fn: F,
+    mut elapsed: E,
+    mut sleep: S,
+) -> Result<T>
+where
+    F: FnMut(Duration) -> Result<Option<T>>,
+    E: FnMut() -> Duration,
+    S: FnMut(Duration),
+{
+    to_ms_checked(timeout)?;
+
     let mut attempts = 0;
 
-    loop {
+    if timeout.is_zero() {
         attempts += 1;
+        return match capture_fn(Duration::ZERO)? {
+            Some(frame) => Ok(frame),
+            None => Err(Error::FrameTimeout {
+                attempts,
+                elapsed: elapsed(),
+            }),
+        };
+    }
 
-        let elapsed = start_time.elapsed();
-        if elapsed > timeout {
-            return Err(Error::FrameTimeout { attempts, elapsed });
+    loop {
+        let elapsed_before_attempt = elapsed();
+        let Some(remaining) = timeout.checked_sub(elapsed_before_attempt) else {
+            return Err(Error::FrameTimeout {
+                attempts,
+                elapsed: elapsed_before_attempt,
+            });
+        };
+
+        if remaining.is_zero() {
+            return Err(Error::FrameTimeout {
+                attempts,
+                elapsed: elapsed_before_attempt,
+            });
         }
 
-        match capture_fn(policy.poll_interval)? {
+        let poll_timeout = policy.poll_interval.min(remaining);
+        attempts += 1;
+
+        match capture_fn(poll_timeout)? {
             Some(frame) => return Ok(frame),
             None => {
-                std::thread::sleep(policy.sleep_between);
+                let elapsed_after_attempt = elapsed();
+                let Some(remaining) = timeout.checked_sub(elapsed_after_attempt) else {
+                    return Err(Error::FrameTimeout {
+                        attempts,
+                        elapsed: elapsed_after_attempt,
+                    });
+                };
+
+                if remaining.is_zero() {
+                    return Err(Error::FrameTimeout {
+                        attempts,
+                        elapsed: elapsed_after_attempt,
+                    });
+                }
+
+                let sleep_duration = policy.sleep_between.min(remaining);
+                if !sleep_duration.is_zero() {
+                    sleep(sleep_duration);
+                }
             }
         }
     }
@@ -666,14 +733,17 @@ impl Receiver {
         )
     }
 
-    /// Capture a zero-copy borrowed video frame - safe to call from multiple threads concurrently.
+    /// Poll for a zero-copy borrowed video frame - safe to call from multiple threads concurrently.
     ///
     /// This returns a `VideoFrameRef` that borrows the NDI SDK's buffer directly,
     /// avoiding any allocation or memcpy. The frame is automatically freed when dropped.
+    /// This is a single polling attempt: it may return `None` when no frame is
+    /// available and does not retry NDI SDK initial synchronization misses.
     ///
     /// **This is the recommended API for performance-critical applications** that can
-    /// process frames in-place. For applications that need to store frames or send them
-    /// across threads, use [`Self::capture_video`] which returns an owned `VideoFrame`.
+    /// process frames in-place and handle polling themselves. For applications that need
+    /// reliable retrying, or need to store frames or send them across threads, use
+    /// [`Self::capture_video`] which returns an owned `VideoFrame`.
     ///
     /// # Performance
     ///
@@ -734,6 +804,10 @@ impl Receiver {
     /// This is the **primary method** for reliable video frame capture. It works around
     /// an NDI SDK behavior where the SDK may return immediately (0ms) during initial
     /// connection instead of blocking for the full timeout duration.
+    ///
+    /// The `timeout` is a total retry budget. Each individual SDK poll is capped to
+    /// the remaining budget, and `Duration::ZERO` performs exactly one nonblocking
+    /// capture attempt.
     ///
     /// ## Why This Method Exists
     ///
@@ -832,14 +906,17 @@ impl Receiver {
         }
     }
 
-    /// Capture a zero-copy borrowed audio frame - safe to call from multiple threads concurrently.
+    /// Poll for a zero-copy borrowed audio frame - safe to call from multiple threads concurrently.
     ///
     /// This returns an `AudioFrameRef` that borrows the NDI SDK's buffer directly,
     /// avoiding any allocation or memcpy. The frame is automatically freed when dropped.
+    /// This is a single polling attempt: it may return `None` when no frame is
+    /// available and does not retry NDI SDK initial synchronization misses.
     ///
     /// **This is the recommended API for performance-critical applications** that can
-    /// process audio in-place. For applications that need to store frames or send them
-    /// across threads, use [`Self::capture_audio`] which returns an owned `AudioFrame`.
+    /// process audio in-place and handle polling themselves. For applications that need
+    /// reliable retrying, or need to store frames or send them across threads, use
+    /// [`Self::capture_audio`] which returns an owned `AudioFrame`.
     ///
     /// # Returns
     ///
@@ -888,6 +965,10 @@ impl Receiver {
     ///
     /// This is the **primary method** for reliable audio frame capture. It automatically
     /// retries internally to handle NDI SDK synchronization behavior.
+    ///
+    /// The `timeout` is a total retry budget. Each individual SDK poll is capped to
+    /// the remaining budget, and `Duration::ZERO` performs exactly one nonblocking
+    /// capture attempt.
     ///
     /// For zero-copy capture that avoids memory allocation and copying, use
     /// [`Self::capture_audio_ref`] instead. For manual polling where you want to handle
@@ -969,14 +1050,17 @@ impl Receiver {
         }
     }
 
-    /// Capture a zero-copy borrowed metadata frame - safe to call from multiple threads concurrently.
+    /// Poll for a zero-copy borrowed metadata frame - safe to call from multiple threads concurrently.
     ///
     /// This returns a `MetadataFrameRef` that borrows the NDI SDK's buffer directly,
     /// avoiding any allocation or string copying. The frame is automatically freed when dropped.
+    /// This is a single polling attempt: it may return `None` when no frame is
+    /// available and does not retry NDI SDK initial synchronization misses.
     ///
     /// **This is the recommended API for performance-critical applications** that can
-    /// process metadata in-place. For applications that need to store metadata or send it
-    /// across threads, use [`Self::capture_metadata`] which returns an owned `MetadataFrame`.
+    /// process metadata in-place and handle polling themselves. For applications that
+    /// need reliable retrying, or need to store metadata or send it across threads, use
+    /// [`Self::capture_metadata`] which returns an owned `MetadataFrame`.
     ///
     /// # Returns
     ///
@@ -1024,6 +1108,10 @@ impl Receiver {
     ///
     /// This is the **primary method** for reliable metadata frame capture. It automatically
     /// retries internally to handle NDI SDK synchronization behavior.
+    ///
+    /// The `timeout` is a total retry budget. Each individual SDK poll is capped to
+    /// the remaining budget, and `Duration::ZERO` performs exactly one nonblocking
+    /// capture attempt.
     ///
     /// For zero-copy capture that avoids memory allocation and string copying, use
     /// [`Self::capture_metadata_ref`] instead. For manual polling where you want to handle
@@ -1445,8 +1533,25 @@ impl ConnectionStats {
 mod tests {
     use super::*;
 
+    use std::cell::Cell;
+
     fn test_source() -> Source {
         Source::default()
+    }
+
+    #[derive(Default)]
+    struct FakeClock {
+        elapsed: Cell<Duration>,
+    }
+
+    impl FakeClock {
+        fn elapsed(&self) -> Duration {
+            self.elapsed.get()
+        }
+
+        fn advance(&self, duration: Duration) {
+            self.elapsed.set(self.elapsed.get() + duration);
+        }
     }
 
     fn assert_raw_receiver_modes(
@@ -1575,56 +1680,240 @@ mod tests {
     }
 
     #[test]
-    fn retry_succeeds_first_attempt() {
-        let result = retry_capture(Duration::from_secs(1), &RetryPolicy::default(), |_| {
-            Ok(Some(42))
-        });
-        assert_eq!(result.unwrap(), 42);
-    }
-
-    #[test]
-    fn retry_succeeds_after_n_attempts() {
-        let attempts = std::cell::Cell::new(0);
-        let result = retry_capture(Duration::from_secs(1), &RetryPolicy::default(), |_| {
-            attempts.set(attempts.get() + 1);
-            if attempts.get() < 3 {
-                Ok(None)
-            } else {
-                Ok(Some(42))
-            }
-        });
-        assert_eq!(result.unwrap(), 42);
-        assert_eq!(attempts.get(), 3);
-    }
-
-    #[test]
-    fn retry_times_out() {
+    fn retry_caps_sub_poll_timeout_to_total_budget() {
+        let clock = FakeClock::default();
         let policy = RetryPolicy {
-            poll_interval: Duration::from_millis(20),
-            sleep_between: Duration::from_millis(5),
+            poll_interval: Duration::from_millis(100),
+            sleep_between: Duration::from_millis(10),
         };
-        let result: Result<i32> = retry_capture(Duration::from_millis(50), &policy, |_| Ok(None));
+        let mut polls = Vec::new();
+
+        let result = retry_capture_with_clock(
+            Duration::from_millis(25),
+            &policy,
+            |poll| {
+                polls.push(poll);
+                Ok(Some(42))
+            },
+            || clock.elapsed(),
+            |_| {},
+        );
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(polls, [Duration::from_millis(25)]);
+    }
+
+    #[test]
+    fn retry_shrinks_later_poll_to_remaining_budget() {
+        let clock = FakeClock::default();
+        let policy = RetryPolicy {
+            poll_interval: Duration::from_millis(40),
+            sleep_between: Duration::from_millis(10),
+        };
+        let mut polls = Vec::new();
+        let mut sleeps = Vec::new();
+
+        let result: Result<i32> = retry_capture_with_clock(
+            Duration::from_millis(50),
+            &policy,
+            |poll| {
+                polls.push(poll);
+                if polls.len() == 1 {
+                    clock.advance(Duration::from_millis(5));
+                } else {
+                    clock.advance(poll);
+                }
+                Ok(None)
+            },
+            || clock.elapsed(),
+            |sleep| {
+                sleeps.push(sleep);
+                clock.advance(sleep);
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(Error::FrameTimeout { attempts: 2, .. })
+        ));
+        assert_eq!(
+            polls,
+            [Duration::from_millis(40), Duration::from_millis(35)]
+        );
+        assert_eq!(sleeps, [Duration::from_millis(10)]);
+    }
+
+    #[test]
+    fn retry_zero_timeout_success_makes_one_nonblocking_attempt() {
+        let clock = FakeClock::default();
+        let mut polls = Vec::new();
+
+        let result = retry_capture_with_clock(
+            Duration::ZERO,
+            &RetryPolicy::default(),
+            |poll| {
+                polls.push(poll);
+                Ok(Some(42))
+            },
+            || clock.elapsed(),
+            |_| panic!("zero-timeout success should not sleep"),
+        );
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(polls, [Duration::ZERO]);
+    }
+
+    #[test]
+    fn retry_zero_timeout_miss_times_out_after_one_attempt() {
+        let clock = FakeClock::default();
+        let mut polls = Vec::new();
+
+        let result: Result<i32> = retry_capture_with_clock(
+            Duration::ZERO,
+            &RetryPolicy::default(),
+            |poll| {
+                polls.push(poll);
+                Ok(None)
+            },
+            || clock.elapsed(),
+            |_| panic!("zero-timeout miss should not sleep"),
+        );
+
         match result {
             Err(Error::FrameTimeout { attempts, elapsed }) => {
-                assert!(attempts > 0, "Should have made at least one attempt");
-                assert!(
-                    elapsed >= Duration::from_millis(50),
-                    "Elapsed time should be at least the timeout"
-                );
+                assert_eq!(attempts, 1);
+                assert_eq!(elapsed, Duration::ZERO);
             }
             _ => panic!("Expected FrameTimeout error"),
         }
+        assert_eq!(polls, [Duration::ZERO]);
+    }
+
+    #[test]
+    fn retry_timeout_counts_only_actual_capture_attempts() {
+        let clock = FakeClock::default();
+        let policy = RetryPolicy {
+            poll_interval: Duration::from_millis(8),
+            sleep_between: Duration::from_millis(5),
+        };
+        let mut polls = Vec::new();
+
+        let result: Result<i32> = retry_capture_with_clock(
+            Duration::from_millis(10),
+            &policy,
+            |poll| {
+                polls.push(poll);
+                clock.advance(Duration::from_millis(10));
+                Ok(None)
+            },
+            || clock.elapsed(),
+            |_| panic!("expired timeout should not sleep"),
+        );
+
+        match result {
+            Err(Error::FrameTimeout { attempts, elapsed }) => {
+                assert_eq!(attempts, 1);
+                assert_eq!(elapsed, Duration::from_millis(10));
+            }
+            _ => panic!("Expected FrameTimeout error"),
+        }
+        assert_eq!(polls, [Duration::from_millis(8)]);
+    }
+
+    #[test]
+    fn retry_caps_sleep_to_remaining_budget() {
+        let clock = FakeClock::default();
+        let policy = RetryPolicy {
+            poll_interval: Duration::from_millis(8),
+            sleep_between: Duration::from_millis(5),
+        };
+        let mut sleeps = Vec::new();
+
+        let result: Result<i32> = retry_capture_with_clock(
+            Duration::from_millis(10),
+            &policy,
+            |poll| {
+                assert_eq!(poll, Duration::from_millis(8));
+                clock.advance(Duration::from_millis(8));
+                Ok(None)
+            },
+            || clock.elapsed(),
+            |sleep| {
+                sleeps.push(sleep);
+                clock.advance(sleep);
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(Error::FrameTimeout { attempts: 1, .. })
+        ));
+        assert_eq!(sleeps, [Duration::from_millis(2)]);
+    }
+
+    #[test]
+    fn retry_validates_total_timeout_before_attempts() {
+        let attempts = Cell::new(0);
+
+        let result: Result<i32> = retry_capture(
+            crate::MAX_TIMEOUT + Duration::from_nanos(1),
+            &RetryPolicy::default(),
+            |_| {
+                attempts.set(attempts.get() + 1);
+                Ok(Some(42))
+            },
+        );
+
+        assert!(matches!(result, Err(Error::InvalidConfiguration(_))));
+        assert_eq!(attempts.get(), 0);
+    }
+
+    #[test]
+    fn retry_succeeds_after_retry_before_timeout() {
+        let clock = FakeClock::default();
+        let attempts = Cell::new(0);
+
+        let result = retry_capture_with_clock(
+            Duration::from_millis(50),
+            &RetryPolicy::default(),
+            |_| {
+                attempts.set(attempts.get() + 1);
+                if attempts.get() == 1 {
+                    Ok(None)
+                } else {
+                    Ok(Some(42))
+                }
+            },
+            || clock.elapsed(),
+            |sleep| clock.advance(sleep),
+        );
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.get(), 2);
     }
 
     #[test]
     fn retry_propagates_error() {
-        let result: Result<i32> =
-            retry_capture(Duration::from_secs(1), &RetryPolicy::default(), |_| {
+        let clock = FakeClock::default();
+        let attempts = Cell::new(0);
+        let mut sleeps = Vec::new();
+
+        let result: Result<i32> = retry_capture_with_clock(
+            Duration::from_secs(1),
+            &RetryPolicy::default(),
+            |_| {
+                attempts.set(attempts.get() + 1);
                 Err(Error::CaptureFailed("test error".into()))
-            });
+            },
+            || clock.elapsed(),
+            |sleep| sleeps.push(sleep),
+        );
+
         assert!(
             matches!(result, Err(Error::CaptureFailed(_))),
             "Should propagate CaptureFailed error"
         );
+        assert_eq!(attempts.get(), 1);
+        assert!(sleeps.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Make reliable receiver capture enforce the caller timeout as a total retry budget.
- Cap per-attempt poll durations and retry sleeps to the remaining budget, including exact zero-timeout behavior.
- Validate total timeouts before retrying and document reliable owned capture vs polling APIs.
- Subtract async spawn-blocking queue delay before delegating to synchronous reliable capture.

Closes #58

## Tests
- cargo test
- cargo test --features tokio
- cargo test --features async-std
- cargo test --all-features
- git diff --check