### PR TITLE
Validate standalone metadata frame layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - **Video and audio frame layout fields are now private**: `VideoFrame` and `AudioFrame` now preserve validated SDK layout invariants after construction. Use getters such as `width()`, `pixel_format()`, `sample_rate()`, `data()`, and controlled mutation methods such as `data_mut()` or `replace_data()` instead of mutating SDK-facing fields directly.
+- **Metadata frame fields are now private and validated**: `MetadataFrame` now preserves UTF-8, interior-NUL, and size invariants with `MetadataFrame::with_data(...) -> Result<_>`, `data()`, `timecode()`, `set_data(...)`, and `set_timecode(...)` instead of public field access.
 - **Unchecked public video layout helpers were removed**: `calculate_line_stride`, `PixelFormat::line_stride`, `PixelFormat::buffer_size`, and `PixelFormatInfo::buffer_len` have been replaced by checked APIs: `try_line_stride`, `try_buffer_size`, and `try_buffer_len`.
 - **Safe compressed-video construction was removed**: `BorrowedVideoFrame::try_from_compressed` is gone because the crate does not yet expose a typed compressed FourCC model. Unsupported compressed or opaque SDK layouts now require the explicit unsafe `BorrowedVideoFrame::from_parts_unchecked` escape hatch.
 - **Receiver `Max` sentinel variants were removed**: `ReceiverColorFormat` and `ReceiverBandwidth` now expose only operational receiver modes and are marked `#[non_exhaustive]`. Code that used `ReceiverColorFormat::Max` or `ReceiverBandwidth::Max` should choose an explicit mode such as `Fastest`, `Best`, `RGBX_RGBA`, `BGRX_BGRA`, `Highest`, `Lowest`, `AudioOnly`, or `MetadataOnly`.
@@ -17,12 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Send-side video and audio construction now share checked layout validation**: `VideoFrameBuilder`, `BorrowedVideoFrame::try_from_uncompressed`, receive/raw conversion, and owned-to-borrowed conversion now use one cached validation model for dimensions, stride, buffer length, metadata, and SDK union-field selection.
+- **Standalone metadata frames now use checked bounded layout validation**: `MetadataFrameRef` validates `NDIlib_metadata_frame_t::length` and `p_data` once at construction, caches the checked layout, returns zero-copy `&str`/`&[u8]` views, rejects invalid UTF-8 explicitly, and no longer scans lengthless receive-side C strings. Send-side metadata now emits an explicit length including the trailing NUL using checked conversion.
 - **Audio builder layout math is checked before allocation**: `AudioFrameBuilder` now rejects non-positive sample rate, channel count, and sample count before converting to `usize`, and uses checked arithmetic for stride, sample count, and total byte size.
 - **Examples and docs use invariant-preserving accessors**: Example programs and doctests now use getters and checked format helpers instead of public layout fields or unchecked size helpers.
 
 ### Added
 
-- **Focused frame-layout validation coverage**: Added tests for invalid borrowed video dimensions, planar layout rejection, oversized audio layouts, invalid send metadata, owned data replacement, and the unsafe raw-FourCC escape hatch.
+- **Focused frame-layout validation coverage**: Added tests for invalid borrowed video dimensions, planar layout rejection, oversized audio layouts, invalid send metadata, owned data replacement, standalone metadata layout validation, and the unsafe raw-FourCC escape hatch.
 
 ## [0.12.0] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ let info = PixelFormat::BGRA.info();  // PixelFormatInfo with bytes_per_pixel, c
 - **Owned Frames:**
   - `VideoFrame` - Owned video frame data with resolution, pixel format, and timing
   - `AudioFrame` - Owned 32-bit float audio samples with channel configuration
-  - `MetadataFrame` - Owned XML metadata for tally, PTZ, and custom data
+  - `MetadataFrame` - Invariant-preserving owned UTF-8 metadata for tally, PTZ, and custom data
 
 - **Borrowed Frames (Zero-Copy):**
   - `VideoFrameRef<'rx>` - Zero-copy video frame reference (eliminates ~475 MB/s memcpy @ 1080p60)
   - `AudioFrameRef<'rx>` - Zero-copy audio frame reference
-  - `MetadataFrameRef<'rx>` - Zero-copy metadata frame reference
+  - `MetadataFrameRef<'rx>` - Validated zero-copy metadata frame reference
   - `BorrowedVideoFrame<'buf>` - Zero-copy send frame (for async transmission)
   - `FrameSyncVideoRef<'fs>` / `FrameSyncAudioRef<'fs>` - Zero-copy frames from `FrameSync`
 

--- a/docs/migration/0.5-to-0.6.md
+++ b/docs/migration/0.5-to-0.6.md
@@ -74,21 +74,14 @@ let frame = AudioFrame::builder()
     .build()?;
 ```
 
-### MetadataFrame Builder Pattern
+### MetadataFrame Construction
 
 **Before (v0.5):**
-```rust
-let frame = MetadataFrame {
-    data: metadata_string,
-    ..Default::default()
-};
-```
+Metadata frames exposed public fields and could be built with a struct literal.
 
 **After (v0.6):**
 ```rust
-let frame = MetadataFrame::builder()
-    .data(metadata_string)
-    .build()?;
+let frame = MetadataFrame::with_data(metadata_string, 0)?;
 ```
 
 ## New Lifetime-Bound Frame Types

--- a/examples/concurrent_capture.rs
+++ b/examples/concurrent_capture.rs
@@ -138,12 +138,13 @@ fn main() -> Result<(), grafton_ndi::Error> {
                 match recv_metadata.capture_metadata_timeout(Duration::from_millis(2500)) {
                     Ok(Some(frame)) => {
                         metadata_count += 1;
-                        let data_len = frame.data.len();
-                        let preview = if frame.data.len() > 50 {
-                            let preview_data = &frame.data[..50];
+                        let data = frame.data();
+                        let data_len = data.len();
+                        let preview = if data.len() > 50 {
+                            let preview_data = &data[..50];
                             format!("{preview_data}...")
                         } else {
-                            frame.data.clone()
+                            data.to_owned()
                         };
                         println!("[METADATA] Received {data_len} bytes: {preview}");
                     }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -6,7 +6,7 @@ use std::{
     ffi::{CStr, CString},
     fmt,
     os::raw::c_char,
-    ptr, slice,
+    ptr, slice, str,
 };
 
 use crate::{
@@ -870,11 +870,7 @@ impl VideoFrame {
         let slice = slice::from_raw_parts(c_frame.p_data, layout.data_len_bytes);
         let data = slice.to_vec();
 
-        let metadata = if c_frame.p_metadata.is_null() {
-            None
-        } else {
-            Some(CString::from(CStr::from_ptr(c_frame.p_metadata)))
-        };
+        let metadata = unsafe { copy_frame_metadata_cstring(c_frame.p_metadata) };
 
         #[allow(clippy::unnecessary_cast)] // Required for Windows where frame_format_type is i32
         let scan_type = ScanType::try_from(c_frame.frame_format_type as u32).map_err(|_| {
@@ -1088,12 +1084,8 @@ impl AudioFrame {
         let slice = unsafe { slice::from_raw_parts(raw.p_data as *const f32, layout.sample_count) };
         let data = slice.to_vec();
 
-        let metadata = if raw.p_metadata.is_null() {
-            None
-        } else {
-            // Copy the string, don't take ownership - SDK will free the original
-            Some(unsafe { CString::from(CStr::from_ptr(raw.p_metadata)) })
-        };
+        // Copy the string, don't take ownership - SDK will free the original.
+        let metadata = unsafe { copy_frame_metadata_cstring(raw.p_metadata) };
 
         Ok(AudioFrame {
             layout,
@@ -1487,13 +1479,18 @@ const MAX_VIDEO_BYTES: usize = 100 * 1024 * 1024;
 /// Comfortably above typical NDI audio frames while preventing unbounded allocations.
 const MAX_AUDIO_BYTES: usize = 64 * 1024 * 1024;
 
+/// Maximum allowed size for standalone metadata frames (4 MiB), including the
+/// SDK-required trailing NUL terminator.
+const MAX_METADATA_BYTES: usize = 4 * 1024 * 1024;
+
 #[derive(Debug, Clone)]
 pub struct MetadataFrame {
-    pub data: String, // Owned metadata (typically XML)
-    pub timecode: i64,
+    data: String, // Owned metadata (typically XML)
+    timecode: i64,
 }
 
 impl MetadataFrame {
+    /// Create an empty metadata frame with default SDK timecode behavior.
     pub fn new() -> Self {
         MetadataFrame {
             data: String::new(),
@@ -1501,15 +1498,68 @@ impl MetadataFrame {
         }
     }
 
-    pub fn with_data(data: String, timecode: i64) -> Self {
-        MetadataFrame { data, timecode }
+    /// Create a metadata frame from UTF-8 text and a timecode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidCString`] if `data` contains an interior NUL byte
+    /// or [`Error::InvalidFrame`] if the SDK metadata length would exceed the
+    /// crate's metadata size limit.
+    pub fn with_data(data: impl Into<String>, timecode: i64) -> Result<Self> {
+        let data = data.into();
+        validate_metadata_text(&data)?;
+        Ok(MetadataFrame { data, timecode })
+    }
+
+    /// Get the metadata text.
+    pub fn data(&self) -> &str {
+        &self.data
+    }
+
+    /// Consume the frame and return the owned metadata text.
+    pub fn into_data(self) -> String {
+        self.data
+    }
+
+    /// Get the timecode.
+    ///
+    /// A value of zero is passed through to the SDK as its default timestamp
+    /// behavior.
+    pub fn timecode(&self) -> i64 {
+        self.timecode
+    }
+
+    /// Replace the metadata text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidCString`] if `data` contains an interior NUL byte
+    /// or [`Error::InvalidFrame`] if the SDK metadata length would exceed the
+    /// crate's metadata size limit.
+    pub fn set_data(&mut self, data: impl Into<String>) -> Result<()> {
+        let data = data.into();
+        validate_metadata_text(&data)?;
+        self.data = data;
+        Ok(())
+    }
+
+    /// Set the timecode.
+    pub fn set_timecode(&mut self, timecode: i64) {
+        self.timecode = timecode;
+    }
+
+    /// Return this frame with an updated timecode.
+    pub fn with_timecode(mut self, timecode: i64) -> Self {
+        self.timecode = timecode;
+        self
     }
 
     /// Convert to raw format for sending
     pub(crate) fn to_raw(&self) -> Result<(CString, NDIlib_metadata_frame_t)> {
-        let c_data = CString::new(self.data.clone()).map_err(Error::InvalidCString)?;
+        let c_data = CString::new(self.data.as_bytes()).map_err(Error::InvalidCString)?;
+        let length = validate_metadata_len_with_nul(c_data.as_bytes_with_nul().len())?;
         let raw = NDIlib_metadata_frame_t {
-            length: c_data.as_bytes().len() as i32,
+            length,
             timecode: self.timecode,
             p_data: c_data.as_ptr() as *mut c_char,
         };
@@ -1517,16 +1567,31 @@ impl MetadataFrame {
     }
 
     /// Create from raw NDI metadata frame (copies the data)
-    pub(crate) fn from_raw(raw: &NDIlib_metadata_frame_t) -> Self {
-        let data = if raw.p_data.is_null() {
-            String::new()
-        } else {
-            unsafe {
-                let c_str = CStr::from_ptr(raw.p_data);
-                c_str.to_string_lossy().into_owned()
-            }
-        };
-        MetadataFrame {
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be an SDK-populated metadata frame whose `p_data` pointer is
+    /// valid for `raw.length` bytes when `length > 0`.
+    #[cfg(test)]
+    pub(crate) unsafe fn from_raw(raw: &NDIlib_metadata_frame_t) -> Result<Self> {
+        let layout = validate_metadata_layout(raw)?;
+        Ok(Self::from_raw_validated(raw, layout))
+    }
+
+    /// Create from a raw NDI metadata frame after its layout has been validated.
+    ///
+    /// # Safety
+    ///
+    /// `layout` must have been produced by `validate_metadata_layout(raw)` while
+    /// the same `raw.p_data` allocation is still valid.
+    pub(crate) unsafe fn from_raw_validated(
+        raw: &NDIlib_metadata_frame_t,
+        layout: ValidatedMetadataLayout,
+    ) -> Self {
+        let bytes = metadata_payload_bytes(raw, layout);
+        let data = str::from_utf8_unchecked(bytes).to_owned();
+
+        Self {
             data,
             timecode: raw.timecode,
         }
@@ -1537,6 +1602,155 @@ impl Default for MetadataFrame {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Validated standalone metadata frame layout information.
+///
+/// The SDK `length` field includes the trailing NUL terminator. A
+/// `len_with_nul` of zero represents the accepted empty null frame
+/// (`length == 0 && p_data == NULL`) and never requires reading from `p_data`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ValidatedMetadataLayout {
+    /// Total SDK metadata length including trailing NUL, or zero for the valid
+    /// empty null frame.
+    pub len_with_nul: usize,
+    /// Public UTF-8 text payload length excluding the trailing NUL.
+    pub text_len: usize,
+}
+
+/// Validate standalone metadata frame layout from raw FFI fields.
+///
+/// This validates only memory layout and UTF-8. XML well-formedness is
+/// intentionally not checked because NDI receivers are expected to tolerate
+/// badly formed XML metadata.
+pub(crate) fn validate_metadata_layout(
+    raw: &NDIlib_metadata_frame_t,
+) -> Result<ValidatedMetadataLayout> {
+    if raw.length < 0 {
+        return Err(Error::InvalidFrame(format!(
+            "Metadata frame has negative length: {}",
+            raw.length
+        )));
+    }
+
+    if raw.length == 0 {
+        if raw.p_data.is_null() {
+            return Ok(ValidatedMetadataLayout {
+                len_with_nul: 0,
+                text_len: 0,
+            });
+        }
+
+        return Err(Error::InvalidFrame(
+            "Metadata frame uses lengthless non-null C-string data".into(),
+        ));
+    }
+
+    if raw.p_data.is_null() {
+        return Err(Error::InvalidFrame(
+            "Metadata frame has non-zero length with null data pointer".into(),
+        ));
+    }
+
+    let len_with_nul = usize::try_from(raw.length).map_err(|_| {
+        Error::InvalidFrame(format!("Invalid metadata length value: {}", raw.length))
+    })?;
+    validate_metadata_len_with_nul(len_with_nul)?;
+
+    let bytes = unsafe { slice::from_raw_parts(raw.p_data.cast::<u8>(), len_with_nul) };
+    if bytes[len_with_nul - 1] != 0 {
+        return Err(Error::InvalidFrame(
+            "Metadata frame length does not include a trailing NUL terminator".into(),
+        ));
+    }
+
+    let payload = &bytes[..len_with_nul - 1];
+    if payload.contains(&0) {
+        return Err(Error::InvalidFrame(
+            "Metadata frame contains an interior NUL byte".into(),
+        ));
+    }
+
+    str::from_utf8(payload).map_err(|err| Error::InvalidUtf8(err.to_string()))?;
+
+    Ok(ValidatedMetadataLayout {
+        len_with_nul,
+        text_len: payload.len(),
+    })
+}
+
+fn validate_metadata_text(data: &str) -> Result<()> {
+    let len_with_nul = data.len().checked_add(1).ok_or_else(|| {
+        Error::InvalidFrame("Metadata length overflow while adding terminator".into())
+    })?;
+    validate_metadata_len_with_nul(len_with_nul)?;
+    CString::new(data.as_bytes()).map_err(Error::InvalidCString)?;
+    Ok(())
+}
+
+fn validate_metadata_len_with_nul(len_with_nul: usize) -> Result<i32> {
+    if len_with_nul == 0 {
+        return Err(Error::InvalidFrame(
+            "Metadata frame length must include a trailing NUL terminator".into(),
+        ));
+    }
+
+    if len_with_nul > MAX_METADATA_BYTES {
+        return Err(Error::InvalidFrame(format!(
+            "Metadata frame exceeds maximum size: {} bytes > {} bytes",
+            len_with_nul, MAX_METADATA_BYTES
+        )));
+    }
+
+    metadata_len_to_i32(len_with_nul)
+}
+
+fn metadata_len_to_i32(len_with_nul: usize) -> Result<i32> {
+    i32::try_from(len_with_nul).map_err(|_| {
+        Error::InvalidFrame(format!(
+            "Metadata frame length {len_with_nul} exceeds SDK i32 range"
+        ))
+    })
+}
+
+fn metadata_payload_bytes(raw: &NDIlib_metadata_frame_t, layout: ValidatedMetadataLayout) -> &[u8] {
+    if layout.text_len == 0 {
+        &[]
+    } else {
+        // SAFETY: `validate_metadata_layout` checked that `p_data` is non-null
+        // for non-empty payloads and that `text_len` is bounded by `length`.
+        unsafe { slice::from_raw_parts(raw.p_data.cast::<u8>(), layout.text_len) }
+    }
+}
+
+/// Audit note: this helper is only for video/audio per-frame `p_metadata`
+/// fields, not standalone `NDIlib_metadata_frame_t::p_data`. The SDK exposes
+/// those per-frame metadata pointers as lengthless C strings, so hardening them
+/// without `CStr::from_ptr` requires a separate API design from issue #60's
+/// bounded standalone metadata layout.
+///
+/// # Safety
+///
+/// When non-null, `p_metadata` must point to a valid NUL-terminated C string
+/// that remains alive for the returned reference lifetime.
+pub(crate) unsafe fn borrowed_frame_metadata_cstr<'a>(
+    p_metadata: *const c_char,
+) -> Option<&'a CStr> {
+    if p_metadata.is_null() {
+        None
+    } else {
+        Some(unsafe { CStr::from_ptr(p_metadata) })
+    }
+}
+
+/// Copy a video/audio per-frame `p_metadata` C string without taking ownership
+/// of the SDK pointer.
+///
+/// # Safety
+///
+/// When non-null, `p_metadata` must point to a valid NUL-terminated C string.
+pub(crate) unsafe fn copy_frame_metadata_cstring(p_metadata: *const c_char) -> Option<CString> {
+    unsafe { borrowed_frame_metadata_cstr(p_metadata) }.map(CString::from)
 }
 
 /// Image format specification for encoding video frames.
@@ -2371,12 +2585,7 @@ impl<'rx> VideoFrameRef<'rx> {
 
     /// Get the metadata as a `CStr`, if present.
     pub fn metadata(&self) -> Option<&CStr> {
-        let p_metadata = self.guard.frame().p_metadata;
-        if p_metadata.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_ptr(p_metadata) })
-        }
+        unsafe { borrowed_frame_metadata_cstr(self.guard.frame().p_metadata) }
     }
 
     /// Get a zero-copy view of the frame data.
@@ -2532,12 +2741,7 @@ impl<'rx> AudioFrameRef<'rx> {
 
     /// Get the metadata as a `CStr`, if present.
     pub fn metadata(&self) -> Option<&CStr> {
-        let p_metadata = self.guard.frame().p_metadata;
-        if p_metadata.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_ptr(p_metadata) })
-        }
+        unsafe { borrowed_frame_metadata_cstr(self.guard.frame().p_metadata) }
     }
 
     /// Get a zero-copy view of the audio data as 32-bit floats.
@@ -2621,7 +2825,7 @@ impl<'rx> fmt::Debug for AudioFrameRef<'rx> {
 /// # let receiver = Receiver::new(&ndi, &options)?;
 /// // Zero-copy capture
 /// if let Some(frame) = receiver.capture_metadata_ref(Duration::from_millis(1000))? {
-///     println!("Metadata: {}", frame.data().to_string_lossy());
+///     println!("Metadata: {}", frame.data());
 ///
 ///     // Frame is freed here when `frame` goes out of scope
 /// }
@@ -2630,6 +2834,9 @@ impl<'rx> fmt::Debug for AudioFrameRef<'rx> {
 /// ```
 pub struct MetadataFrameRef<'rx> {
     guard: RecvMetadataGuard<'rx>,
+    /// Cached validated layout information. Computed once at construction time;
+    /// `data()` and `as_bytes()` use this cached value.
+    layout: ValidatedMetadataLayout,
 }
 
 impl<'rx> MetadataFrameRef<'rx> {
@@ -2639,8 +2846,10 @@ impl<'rx> MetadataFrameRef<'rx> {
     ///
     /// The caller must ensure the guard was created from a valid NDI receiver
     /// and contains a frame populated by `NDIlib_recv_capture_v3`.
-    pub(crate) unsafe fn new(guard: RecvMetadataGuard<'rx>) -> Self {
-        Self { guard }
+    pub(crate) unsafe fn new(guard: RecvMetadataGuard<'rx>) -> Result<Self> {
+        let layout = validate_metadata_layout(guard.frame())?;
+
+        Ok(Self { guard, layout })
     }
 
     /// Get the timecode.
@@ -2648,20 +2857,21 @@ impl<'rx> MetadataFrameRef<'rx> {
         self.guard.frame().timecode
     }
 
-    /// Get a zero-copy view of the metadata as a `CStr`.
+    /// Get a zero-copy view of the metadata text.
     ///
     /// This returns a reference directly into the NDI SDK's buffer.
     /// No allocation or string copying is performed.
-    ///
-    /// Returns an empty `CStr` if the metadata pointer is null.
-    pub fn data(&self) -> &CStr {
-        let p_data = self.guard.frame().p_data;
-        if p_data.is_null() {
-            // Return empty CStr for null pointer
-            c""
-        } else {
-            unsafe { CStr::from_ptr(p_data) }
-        }
+    pub fn data(&self) -> &str {
+        let bytes = self.as_bytes();
+        // SAFETY: `validate_metadata_layout` checked UTF-8 before this
+        // borrowed frame was constructed.
+        unsafe { str::from_utf8_unchecked(bytes) }
+    }
+
+    /// Get a zero-copy view of the metadata UTF-8 payload bytes, excluding the
+    /// SDK trailing NUL terminator.
+    pub fn as_bytes(&self) -> &[u8] {
+        metadata_payload_bytes(self.guard.frame(), self.layout)
     }
 
     /// Convert this borrowed frame to an owned `MetadataFrame`.
@@ -2669,7 +2879,7 @@ impl<'rx> MetadataFrameRef<'rx> {
     /// This performs a string copy, allowing the frame to outlive
     /// the NDI buffer and be sent across threads.
     pub fn to_owned(&self) -> MetadataFrame {
-        MetadataFrame::from_raw(self.guard.frame())
+        unsafe { MetadataFrame::from_raw_validated(self.guard.frame(), self.layout) }
     }
 }
 
@@ -2677,6 +2887,7 @@ impl<'rx> fmt::Debug for MetadataFrameRef<'rx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MetadataFrameRef")
             .field("data", &self.data())
+            .field("data (bytes)", &self.as_bytes().len())
             .field("timecode", &self.timecode())
             .finish()
     }
@@ -3294,6 +3505,268 @@ mod tests {
     fn test_max_audio_bytes_constant() {
         // Verify the constant is set to 64 MiB as specified
         assert_eq!(MAX_AUDIO_BYTES, 64 * 1024 * 1024);
+    }
+
+    /// Test that MAX_METADATA_BYTES constant is properly defined.
+    #[test]
+    fn test_max_metadata_bytes_constant() {
+        assert_eq!(MAX_METADATA_BYTES, 4 * 1024 * 1024);
+    }
+
+    fn metadata_raw_from_bytes(data: &mut [u8], length: i32) -> NDIlib_metadata_frame_t {
+        NDIlib_metadata_frame_t {
+            length,
+            timecode: 12345,
+            p_data: data.as_mut_ptr().cast::<c_char>(),
+        }
+    }
+
+    fn null_metadata_raw(length: i32) -> NDIlib_metadata_frame_t {
+        NDIlib_metadata_frame_t {
+            length,
+            timecode: 12345,
+            p_data: ptr::null_mut(),
+        }
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_accepts_empty_null_frame() {
+        let raw = null_metadata_raw(0);
+        let layout = validate_metadata_layout(&raw).expect("empty null frame is valid");
+
+        assert_eq!(
+            layout,
+            ValidatedMetadataLayout {
+                len_with_nul: 0,
+                text_len: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_accepts_one_byte_empty_payload() {
+        let mut data = vec![0u8];
+        let raw = metadata_raw_from_bytes(&mut data, 1);
+        let layout = validate_metadata_layout(&raw).expect("explicit empty payload is valid");
+
+        assert_eq!(layout.len_with_nul, 1);
+        assert_eq!(layout.text_len, 0);
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_accepts_utf8_with_bounded_length() {
+        let mut data = "<ndi tally=\"preview\"/>".as_bytes().to_vec();
+        data.push(0);
+        let length = data.len() as i32;
+        let raw = metadata_raw_from_bytes(&mut data, length);
+        let layout = validate_metadata_layout(&raw).expect("valid UTF-8 metadata");
+
+        assert_eq!(layout.len_with_nul, data.len());
+        assert_eq!(layout.text_len, data.len() - 1);
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_ignores_bytes_after_length() {
+        let mut data = b"ok\0\0\xFF".to_vec();
+        let raw = metadata_raw_from_bytes(&mut data, 3);
+        let layout = validate_metadata_layout(&raw).expect("extra bytes after length ignored");
+
+        assert_eq!(layout.text_len, 2);
+        let owned = unsafe { MetadataFrame::from_raw_validated(&raw, layout) };
+        assert_eq!(owned.data(), "ok");
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_negative_length() {
+        let raw = null_metadata_raw(-1);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_lengthless_non_null_data() {
+        let mut data = vec![0u8];
+        let raw = metadata_raw_from_bytes(&mut data, 0);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_nonzero_length_null_data() {
+        let raw = null_metadata_raw(1);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_missing_trailing_nul() {
+        let mut data = b"abc".to_vec();
+        let length = data.len() as i32;
+        let raw = metadata_raw_from_bytes(&mut data, length);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_interior_nul() {
+        let mut data = b"a\0b\0".to_vec();
+        let length = data.len() as i32;
+        let raw = metadata_raw_from_bytes(&mut data, length);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_oversized_length_before_reading() {
+        let mut data = vec![0u8];
+        let raw = metadata_raw_from_bytes(&mut data, (MAX_METADATA_BYTES + 1) as i32);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_metadata_layout_rejects_invalid_utf8() {
+        let mut data = vec![0xFF, 0];
+        let length = data.len() as i32;
+        let raw = metadata_raw_from_bytes(&mut data, length);
+
+        assert!(matches!(
+            validate_metadata_layout(&raw),
+            Err(Error::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_metadata_frame_constructor_and_accessors_preserve_text() {
+        let frame = MetadataFrame::with_data("<ndi_product/>", 9876).unwrap();
+
+        assert_eq!(frame.data(), "<ndi_product/>");
+        assert_eq!(frame.timecode(), 9876);
+        assert_eq!(frame.clone().into_data(), "<ndi_product/>");
+    }
+
+    #[test]
+    fn test_metadata_frame_rejects_interior_nul_input() {
+        assert!(matches!(
+            MetadataFrame::with_data("bad\0metadata", 0),
+            Err(Error::InvalidCString(_))
+        ));
+
+        let mut frame = MetadataFrame::new();
+        assert!(matches!(
+            frame.set_data("bad\0metadata"),
+            Err(Error::InvalidCString(_))
+        ));
+    }
+
+    #[test]
+    fn test_metadata_frame_rejects_oversized_input() {
+        let oversized = "x".repeat(MAX_METADATA_BYTES);
+
+        assert!(matches!(
+            MetadataFrame::with_data(oversized, 0),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_metadata_frame_setters_preserve_invariants() {
+        let mut frame = MetadataFrame::new();
+
+        frame.set_data("updated").unwrap();
+        frame.set_timecode(42);
+
+        assert_eq!(frame.data(), "updated");
+        assert_eq!(frame.timecode(), 42);
+        assert_eq!(MetadataFrame::new().with_timecode(7).timecode(), 7);
+    }
+
+    #[test]
+    fn test_metadata_frame_from_raw_validated_copies_only_payload() {
+        let mut data = b"copy-me\0\0\xFF".to_vec();
+        let raw = metadata_raw_from_bytes(&mut data, 8);
+        let layout = validate_metadata_layout(&raw).unwrap();
+        let frame = unsafe { MetadataFrame::from_raw_validated(&raw, layout) };
+
+        assert_eq!(frame.data(), "copy-me");
+        assert_eq!(frame.timecode(), 12345);
+    }
+
+    #[test]
+    fn test_metadata_frame_from_raw_reports_invalid_utf8() {
+        let mut data = vec![0xFF, 0];
+        let raw = metadata_raw_from_bytes(&mut data, 2);
+
+        assert!(matches!(
+            unsafe { MetadataFrame::from_raw(&raw) },
+            Err(Error::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_metadata_frame_to_raw_includes_trailing_nul() {
+        let frame = MetadataFrame::with_data("abc", 101).unwrap();
+        let (c_data, raw) = frame.to_raw().unwrap();
+
+        assert_eq!(raw.length, 4);
+        assert_eq!(raw.timecode, 101);
+        assert_eq!(c_data.as_bytes_with_nul(), b"abc\0");
+    }
+
+    #[test]
+    fn test_empty_metadata_frame_to_raw_sends_explicit_nul() {
+        let frame = MetadataFrame::new();
+        let (c_data, raw) = frame.to_raw().unwrap();
+
+        assert_eq!(raw.length, 1);
+        assert_eq!(c_data.as_bytes_with_nul(), b"\0");
+    }
+
+    #[test]
+    fn test_metadata_raw_length_conversion_is_checked() {
+        assert!(metadata_len_to_i32(i32::MAX as usize).is_ok());
+        assert!(matches!(
+            metadata_len_to_i32(i32::MAX as usize + 1),
+            Err(Error::InvalidFrame(_))
+        ));
+    }
+
+    #[test]
+    fn test_metadata_frame_ref_uses_cached_layout() {
+        use crate::capture::RecvMetadataGuard;
+
+        let mut data = b"zero-copy\0\0\xFF".to_vec();
+        let raw = metadata_raw_from_bytes(&mut data, 10);
+        let guard = unsafe { RecvMetadataGuard::new(ptr::null_mut(), raw) };
+        let frame_ref = unsafe { MetadataFrameRef::new(guard) }.expect("valid metadata ref");
+
+        assert_eq!(frame_ref.data(), "zero-copy");
+        assert_eq!(frame_ref.as_bytes(), b"zero-copy");
+        assert_eq!(frame_ref.layout.text_len, 9);
+
+        let owned = frame_ref.to_owned();
+        assert_eq!(owned.data(), "zero-copy");
+        assert_eq!(owned.timecode(), 12345);
+
+        std::mem::forget(frame_ref);
     }
 
     /// Test that audio frames with overflow in checked_mul are rejected

--- a/src/framesync.rs
+++ b/src/framesync.rs
@@ -80,9 +80,9 @@ use std::{ffi::CStr, fmt, marker::PhantomData, mem::ManuallyDrop, num::NonZeroI3
 
 use crate::{
     frames::{
-        validate_audio_layout, validate_audio_layout_allow_empty, validate_video_layout,
-        AudioFormat, AudioFrame, LineStrideOrSize, PixelFormat, ScanType, ValidatedAudioLayout,
-        ValidatedVideoLayout, VideoFrame,
+        borrowed_frame_metadata_cstr, validate_audio_layout, validate_audio_layout_allow_empty,
+        validate_video_layout, AudioFormat, AudioFrame, LineStrideOrSize, PixelFormat, ScanType,
+        ValidatedAudioLayout, ValidatedVideoLayout, VideoFrame,
     },
     ndi_lib::*,
     receiver::Receiver,
@@ -719,11 +719,7 @@ impl<'fs> FrameSyncVideoRef<'fs> {
 
     /// Get the metadata as a `CStr`, if present.
     pub fn metadata(&self) -> Option<&CStr> {
-        if self.guard.frame().p_metadata.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_ptr(self.guard.frame().p_metadata) })
-        }
+        unsafe { borrowed_frame_metadata_cstr(self.guard.frame().p_metadata) }
     }
 
     /// Get a zero-copy view of the frame data.
@@ -848,11 +844,7 @@ impl<'fs> FrameSyncAudioRef<'fs> {
 
     /// Get the metadata as a `CStr`, if present.
     pub fn metadata(&self) -> Option<&CStr> {
-        if self.guard.frame().p_metadata.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_ptr(self.guard.frame().p_metadata) })
-        }
+        unsafe { borrowed_frame_metadata_cstr(self.guard.frame().p_metadata) }
     }
 
     /// Get a zero-copy view of the audio data as 32-bit floats.

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1081,8 +1081,7 @@ impl Receiver {
     /// // Zero-copy capture
     /// if let Some(frame) = receiver.capture_metadata_ref(Duration::from_secs(1))? {
     ///     // Process in place - no copy needed
-    ///     let metadata_str = frame.data().to_string_lossy();
-    ///     println!("Metadata: {}", metadata_str);
+    ///     println!("Metadata: {}", frame.data());
     /// }
     /// # Ok(())
     /// # }
@@ -1096,7 +1095,7 @@ impl Receiver {
         // SAFETY: self.instance is a valid NDI receiver instance
         match unsafe { capture_metadata_raw(self.instance, timeout_ms) } {
             CaptureResult::Frame(guard) => {
-                let frame_ref = unsafe { MetadataFrameRef::new(guard) };
+                let frame_ref = unsafe { MetadataFrameRef::new(guard)? };
                 Ok(Some(frame_ref))
             }
             CaptureResult::None => Ok(None),
@@ -1139,7 +1138,7 @@ impl Receiver {
     /// # let options = ReceiverOptions::builder(source).build();
     /// # let receiver = Receiver::new(&ndi, &options)?;
     /// let frame = receiver.capture_metadata(Duration::from_secs(5))?;
-    /// println!("Metadata: {}", frame.data);
+    /// println!("Metadata: {}", frame.data());
     /// # Ok(())
     /// # }
     /// ```

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -781,7 +781,8 @@ impl Sender {
     ///
     /// # Errors
     ///
-    /// Returns an error if the metadata string contains a null byte.
+    /// Returns an error if the metadata contains an interior NUL byte, exceeds
+    /// the metadata size limit, or cannot fit the SDK length field.
     pub fn send_metadata(&self, metadata_frame: &MetadataFrame) -> Result<()> {
         let (_c_data, raw) = metadata_frame.to_raw()?;
         unsafe {
@@ -891,7 +892,8 @@ impl Sender {
     ///
     /// # Errors
     ///
-    /// Returns an error if the metadata string contains a null byte.
+    /// Returns an error if the metadata contains an interior NUL byte, exceeds
+    /// the metadata size limit, or cannot fit the SDK length field.
     pub fn add_connection_metadata(&self, metadata_frame: &MetadataFrame) -> Result<()> {
         let (_c_data, raw) = metadata_frame.to_raw()?;
         unsafe { NDIlib_send_add_connection_metadata(self.inner.instance, &raw) }


### PR DESCRIPTION
## Summary
- validate standalone NDI metadata frames with a bounded checked layout before safe access
- make MetadataFrame invariant-preserving with private fields and fallible construction/mutation
- propagate receive-side metadata validation errors and update docs/examples for accessors
- audit remaining metadata-related CStr::from_ptr usage as video/audio p_metadata, a separate lengthless SDK surface

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo test --doc --all-features

Closes #60