### PR TITLE
Fix image encoding pixel conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Standalone metadata frames now use checked bounded layout validation**: `MetadataFrameRef` validates `NDIlib_metadata_frame_t::length` and `p_data` once at construction, caches the checked layout, returns zero-copy `&str`/`&[u8]` views, rejects invalid UTF-8 explicitly, and no longer scans lengthless receive-side C strings. Send-side metadata now emits an explicit length including the trailing NUL using checked conversion.
 - **Audio builder layout math is checked before allocation**: `AudioFrameBuilder` now rejects non-positive sample rate, channel count, and sample count before converting to `usize`, and uses checked arithmetic for stride, sample count, and total byte size.
 - **Examples and docs use invariant-preserving accessors**: Example programs and doctests now use getters and checked format helpers instead of public layout fields or unchecked size helpers.
+- **Image encoding is now enabled by default**: PNG/JPEG/data URL helpers are included in the default feature set because they are mature crate capabilities. Size-sensitive users can still opt out with `default-features = false`; codec dependencies remain scoped to the `image-encoding` feature.
+- **PNG and JPEG encoding share one image conversion path**: Image encoders now use a private row-stride-aware conversion helper, and the PNG receive example delegates to `VideoFrame::encode_png()` instead of duplicating pixel-format policy.
+- **Removed unused image build dependency**: Removed the unconditional `lodepng` build dependency so minimal builds do not compile an unused codec crate.
 
 ### Added
 
 - **Focused frame-layout validation coverage**: Added tests for invalid borrowed video dimensions, planar layout rejection, oversized audio layouts, invalid send metadata, owned data replacement, standalone metadata layout validation, and the unsafe raw-FourCC escape hatch.
+- **Exact image encoding coverage**: Added feature-gated tests that decode PNG output for exact RGBA pixels, cover RGBX/BGRX opaque alpha behavior, padded rows, JPEG quality validation, and oversized JPEG dimensions.
+
+### Fixed
+
+- **RGBX/BGRX PNG output now treats X bytes as padding**: PNG snapshots from padding formats now force alpha to 255 instead of exposing padding bytes as alpha, while RGBA/BGRA preserve real alpha.
+- **Image encoding accepts valid padded rows**: PNG and JPEG encoding now consume only active pixels from each line according to the validated line stride instead of rejecting valid row padding.
 
 ## [0.12.0] - 2026-05-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ exclude = ["target/", ".gitignore", ".github/", "NDI_6_SDK.zip", "docs/"]
 [dependencies]
 num_enum = "0.7.6"
 once_cell = "1.21"
-png = "0.18"
 thiserror = "2.0.18"
 
 # Optional dependencies for image-encoding feature
 base64 = { version = "0.22", optional = true }
 jpeg-encoder = { version = "0.7", optional = true }
+png = { version = "0.18", optional = true }
 
 # Optional dependencies for async runtime integration
 tokio = { version = "1.52", optional = true, features = ["rt", "rt-multi-thread", "sync", "macros"] }
@@ -39,8 +39,8 @@ default = []
 # This includes async video completion callbacks and other advanced functionality
 advanced_sdk = []
 # Enable image encoding support (PNG, JPEG, data URLs)
-# Adds dependencies: base64, jpeg-encoder
-image-encoding = ["dep:base64", "dep:jpeg-encoder"]
+# Adds dependencies: base64, jpeg-encoder, png
+image-encoding = ["dep:base64", "dep:jpeg-encoder", "dep:png"]
 # Enable async runtime integration for Tokio
 # Adds dependency: tokio
 tokio = ["dep:tokio"]
@@ -50,3 +50,7 @@ async-std = ["dep:async-std"]
 
 [dev-dependencies]
 ctrlc = "3.5"
+
+[[example]]
+name = "NDIlib_Recv_PNG"
+required-features = ["image-encoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,14 @@ async-std = { version = "1.13", optional = true, features = ["attributes"] }
 
 [build-dependencies]
 bindgen = "0.72.1"
-lodepng = "3.12.2"
 
 [features]
-default = []
+default = ["image-encoding"]
 # Enable NDI Advanced SDK features (requires NDI Advanced SDK)
 # This includes async video completion callbacks and other advanced functionality
 advanced_sdk = []
-# Enable image encoding support (PNG, JPEG, data URLs)
-# Adds dependencies: base64, jpeg-encoder, png
+# Enable image encoding support (PNG, JPEG, data URLs).
+# Enabled by default. Use `default-features = false` for a minimal build.
 image-encoding = ["dep:base64", "dep:jpeg-encoder", "dep:png"]
 # Enable async runtime integration for Tokio
 # Adds dependency: tokio

--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ Add to your `Cargo.toml`:
 [dependencies]
 grafton-ndi = "0.12"
 
+# For a minimal build without PNG/JPEG/data URL helpers
+# grafton-ndi = { version = "0.12", default-features = false }
+
 # For NDI Advanced SDK features (optional)
 # grafton-ndi = { version = "0.12", features = ["advanced_sdk"] }
 
-# For image encoding support (PNG/JPEG)
+# Image encoding support (PNG/JPEG/data URLs) is enabled by default
 # grafton-ndi = { version = "0.12", features = ["image-encoding"] }
 
 # For async runtime integration

--- a/examples/NDIlib_Recv_PNG.rs
+++ b/examples/NDIlib_Recv_PNG.rs
@@ -9,25 +9,23 @@
 //!
 //! 1. Using `capture_video()` for reliable frame capture with
 //!    automatic retry logic (handles NDI SDK timeout quirks internally)
-//! 2. Stride validation - Prevents corrupted images when stride != width * 4
-//! 3. Format verification - Ensures we actually get RGBA/RGBX format
-//! 4. Compressed format detection - Warns about unsupported formats
+//! 2. `VideoFrame::encode_png()` for crate-provided image conversion
+//! 3. Correct handling for RGBX/BGRX padding bytes and padded rows
 //!
-//! Run with: `cargo run --example NDIlib_Recv_PNG`
+//! Run with: `cargo run --features image-encoding --example NDIlib_Recv_PNG`
 //!
 //! Optional arguments:
-//! - IP address to search: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100`
-//! - Multiple IPs: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100 10.0.0.0/24`
-//! - Custom output file: `cargo run --example NDIlib_Recv_PNG -- --output MyImage.png`
-//! - Both: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100 --output MyImage.png`
+//! - IP address to search: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- 192.168.0.100`
+//! - Multiple IPs: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- 192.168.0.100 10.0.0.0/24`
+//! - Custom output file: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- --output MyImage.png`
+//! - Both: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- 192.168.0.100 --output MyImage.png`
 
 use grafton_ndi::{
-    Error, Finder, FinderOptions, PixelFormat, Receiver, ReceiverColorFormat, ReceiverOptions, NDI,
+    Error, Finder, FinderOptions, Receiver, ReceiverColorFormat, ReceiverOptions, NDI,
 };
 
 use std::{
-    env,
-    fs::File,
+    env, fs,
     time::{Duration, Instant},
 };
 
@@ -110,16 +108,14 @@ fn main() -> Result<(), Error> {
     println!("  Resolution: {width}x{height}");
     let fourcc = video_frame.pixel_format();
     println!("  Format: {fourcc:?}");
-    let line_stride = match video_frame.line_stride_or_size() {
-        grafton_ndi::LineStrideOrSize::LineStrideBytes(stride) => stride,
-        grafton_ndi::LineStrideOrSize::DataSizeBytes(_) => {
-            eprintln!("ERROR: Expected line stride but got data size");
-            return Err(Error::InvalidFrame(
-                "Frame has data size instead of line stride".into(),
-            ));
+    match video_frame.line_stride_or_size() {
+        grafton_ndi::LineStrideOrSize::LineStrideBytes(stride) => {
+            println!("  Line stride: {stride} bytes");
         }
-    };
-    println!("  Line stride: {line_stride} bytes");
+        grafton_ndi::LineStrideOrSize::DataSizeBytes(size) => {
+            println!("  Data size layout: {size} bytes");
+        }
+    }
     let data_size = video_frame.data().len();
     println!("  Data size: {data_size} bytes");
     let frame_rate_n = video_frame.frame_rate_n();
@@ -128,52 +124,9 @@ fn main() -> Result<(), Error> {
     let timecode = video_frame.timecode();
     println!("  Timecode: {timecode:016x}");
 
-    match video_frame.pixel_format() {
-        PixelFormat::RGBA | PixelFormat::RGBX => {
-            println!("  ✓ Got requested RGBA/RGBX format");
-        }
-        _ => {
-            let format = video_frame.pixel_format();
-            eprintln!("  ⚠ Warning: Got unexpected format {format:?}, PNG may fail");
-        }
-    }
-
-    // CRITICAL: Verify stride matches width to prevent corrupted images
-    let expected_stride = video_frame.width() * 4;
-    let actual_stride = line_stride;
-
-    if actual_stride != expected_stride {
-        // If stride != width * 4, we would need to handle row padding
-        return Err(Error::InitializationFailed(format!(
-            "Line stride ({actual_stride}) doesn't match width * 4 ({expected_stride}). \
-             This would require handling row padding which this example doesn't implement."
-        )));
-    }
-
-    let expected_uncompressed_size = (video_frame.width() * video_frame.height() * 4) as usize;
-    if video_frame.data().len() < expected_uncompressed_size / 2 {
-        let actual_size = video_frame.data().len();
-        eprintln!(
-            "  ⚠ Warning: Frame data size ({actual_size} bytes) is much smaller than expected"
-        );
-        eprintln!("            uncompressed size ({expected_uncompressed_size} bytes). This might be a compressed");
-        eprintln!("            format that needs decoding before saving as PNG.");
-    }
-
     println!("\nSaving frame as PNG...");
-    let file = File::create(output_file)?;
-    let mut encoder = png::Encoder::new(
-        file,
-        video_frame.width() as u32,
-        video_frame.height() as u32,
-    );
-    encoder.set_color(png::ColorType::Rgba);
-    encoder.set_depth(png::BitDepth::Eight);
-
-    encoder
-        .write_header()
-        .and_then(|mut writer| writer.write_image_data(video_frame.data()))
-        .map_err(|e| Error::InitializationFailed(format!("PNG encoding failed: {e}")))?;
+    let png_bytes = video_frame.encode_png()?;
+    fs::write(output_file, png_bytes)?;
 
     println!("✓ Saved frame as {output_file}");
     println!("\nExample completed successfully!");

--- a/examples/NDIlib_Recv_PNG.rs
+++ b/examples/NDIlib_Recv_PNG.rs
@@ -12,13 +12,15 @@
 //! 2. `VideoFrame::encode_png()` for crate-provided image conversion
 //! 3. Correct handling for RGBX/BGRX padding bytes and padded rows
 //!
-//! Run with: `cargo run --features image-encoding --example NDIlib_Recv_PNG`
+//! Run with: `cargo run --example NDIlib_Recv_PNG`
+//!
+//! If default features are disabled, add `--features image-encoding`.
 //!
 //! Optional arguments:
-//! - IP address to search: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- 192.168.0.100`
-//! - Multiple IPs: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- 192.168.0.100 10.0.0.0/24`
-//! - Custom output file: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- --output MyImage.png`
-//! - Both: `cargo run --features image-encoding --example NDIlib_Recv_PNG -- 192.168.0.100 --output MyImage.png`
+//! - IP address to search: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100`
+//! - Multiple IPs: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100 10.0.0.0/24`
+//! - Custom output file: `cargo run --example NDIlib_Recv_PNG -- --output MyImage.png`
+//! - Both: `cargo run --example NDIlib_Recv_PNG -- 192.168.0.100 --output MyImage.png`
 
 use grafton_ndi::{
     Error, Finder, FinderOptions, Receiver, ReceiverColorFormat, ReceiverOptions, NDI,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -2,6 +2,8 @@
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
+#[cfg(feature = "image-encoding")]
+use std::borrow::Cow;
 use std::{
     ffi::{CStr, CString},
     fmt,
@@ -587,21 +589,23 @@ impl VideoFrame {
     ///
     /// # Supported Formats
     ///
-    /// - `RGBA` / `RGBX`: Direct encoding (fastest)
-    /// - `BGRA` / `BGRX`: Swaps red and blue channels
+    /// - `RGBA`: Direct encoding when rows are tightly packed
+    /// - `BGRA`: Swaps red and blue channels and preserves alpha
+    /// - `RGBX`: Treats the fourth byte as padding and writes opaque alpha
+    /// - `BGRX`: Swaps red/blue and writes opaque alpha
     /// - Other formats: Returns an error (unsupported for now)
     ///
     /// # Stride Handling
     ///
-    /// This method validates that the frame's line stride matches the expected stride for
-    /// the pixel format. If the stride doesn't match (indicating row padding), an error
-    /// is returned. This prevents corrupted image output.
+    /// This method consumes active pixels row-by-row according to the frame's
+    /// validated line stride. Valid row padding is skipped.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - The frame format is not RGBA/RGBX/BGRA/BGRX
-    /// - The line stride doesn't match the expected value (has padding)
+    /// - The frame uses data-size layout instead of line-stride layout
+    /// - The backing data length does not match the validated layout
     /// - PNG encoding fails
     ///
     /// # Example
@@ -628,63 +632,18 @@ impl VideoFrame {
     pub fn encode_png(&self) -> Result<Vec<u8>> {
         use png::{BitDepth, ColorType, Encoder};
 
-        // Validate format
-        let bytes_per_pixel = match self.pixel_format() {
-            PixelFormat::RGBA | PixelFormat::RGBX => 4,
-            PixelFormat::BGRA | PixelFormat::BGRX => 4,
-            _ => {
-                let pixel_format = self.pixel_format();
-                return Err(Error::InvalidFrame(format!(
-                    "Unsupported format for PNG encoding: {pixel_format:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
-                )));
-            }
-        };
-
-        // Validate stride
-        let expected_stride = self.width() * bytes_per_pixel;
-        let actual_stride = match self.line_stride_or_size() {
-            LineStrideOrSize::LineStrideBytes(stride) => stride,
-            LineStrideOrSize::DataSizeBytes(_) => {
-                return Err(Error::InvalidFrame(
-                    "Cannot encode image from compressed/data-size format. Use LineStrideBytes."
-                        .into(),
-                ));
-            }
-        };
-
-        if actual_stride != expected_stride {
-            return Err(Error::InvalidFrame(format!(
-                "Line stride ({actual_stride}) doesn't match width * {bytes_per_pixel} ({expected_stride}). \
-                 Row padding is not supported for image encoding."
-            )));
-        }
-
-        // Handle color format conversion if needed
-        let rgba_data: Vec<u8> = match self.pixel_format() {
-            PixelFormat::RGBA | PixelFormat::RGBX => {
-                // Already in correct format, use as-is
-                self.data.to_vec()
-            }
-            PixelFormat::BGRA | PixelFormat::BGRX => {
-                // Swap R and B channels (BGRA -> RGBA)
-                let mut rgba = self.data.to_vec();
-                for chunk in rgba.chunks_exact_mut(4) {
-                    chunk.swap(0, 2); // Swap B and R
-                }
-                rgba
-            }
-            _ => unreachable!("Format already validated above"),
-        };
+        let image = ImagePixelSource::new(self.layout, &self.data)?;
+        let (rgba_data, width, height) = image.png_rgba_input()?;
 
         // Encode to PNG
         let mut png_data = Vec::new();
-        let mut encoder = Encoder::new(&mut png_data, self.width() as u32, self.height() as u32);
+        let mut encoder = Encoder::new(&mut png_data, width, height);
         encoder.set_color(ColorType::Rgba);
         encoder.set_depth(BitDepth::Eight);
 
         encoder
             .write_header()
-            .and_then(|mut writer| writer.write_image_data(&rgba_data))
+            .and_then(|mut writer| writer.write_image_data(rgba_data.as_ref()))
             .map_err(|e| Error::InvalidFrame(format!("PNG encoding failed: {e}")))?;
 
         Ok(png_data)
@@ -701,15 +660,18 @@ impl VideoFrame {
     ///
     /// # Supported Formats
     ///
-    /// - `RGBA` / `RGBX`: Strips alpha channel
-    /// - `BGRA` / `BGRX`: Swaps red/blue and strips alpha
+    /// - `RGBA` / `RGBX`: Emits RGB
+    /// - `BGRA` / `BGRX`: Swaps red/blue and emits RGB
     /// - Other formats: Returns an error (unsupported for now)
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - The frame format is not RGBA/RGBX/BGRA/BGRX
-    /// - The line stride doesn't match the expected value (has padding)
+    /// - The frame uses data-size layout instead of line-stride layout
+    /// - The backing data length does not match the validated layout
+    /// - The quality is outside `1..=100`
+    /// - The dimensions exceed JPEG's `u16` width/height range
     /// - JPEG encoding fails
     ///
     /// # Example
@@ -736,66 +698,14 @@ impl VideoFrame {
     pub fn encode_jpeg(&self, quality: u8) -> Result<Vec<u8>> {
         use jpeg_encoder::{ColorType as JpegColorType, Encoder as JpegEncoder};
 
-        // Validate format
-        let bytes_per_pixel = match self.pixel_format() {
-            PixelFormat::RGBA | PixelFormat::RGBX => 4,
-            PixelFormat::BGRA | PixelFormat::BGRX => 4,
-            _ => {
-                let pixel_format = self.pixel_format();
-                return Err(Error::InvalidFrame(format!(
-                    "Unsupported format for JPEG encoding: {pixel_format:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
-                )));
-            }
-        };
-
-        // Validate stride
-        let expected_stride = self.width() * bytes_per_pixel;
-        let actual_stride = match self.line_stride_or_size() {
-            LineStrideOrSize::LineStrideBytes(stride) => stride,
-            LineStrideOrSize::DataSizeBytes(_) => {
-                return Err(Error::InvalidFrame(
-                    "Cannot encode image from compressed/data-size format. Use LineStrideBytes."
-                        .into(),
-                ));
-            }
-        };
-
-        if actual_stride != expected_stride {
-            return Err(Error::InvalidFrame(format!(
-                "Line stride ({actual_stride}) doesn't match width * {bytes_per_pixel} ({expected_stride}). \
-                 Row padding is not supported for image encoding."
-            )));
-        }
-
-        // Convert to RGB (JPEG doesn't support alpha channel)
-        let rgb_data: Vec<u8> = match self.pixel_format() {
-            PixelFormat::RGBA | PixelFormat::RGBX => {
-                // Strip alpha channel: RGBA -> RGB
-                self.data
-                    .chunks_exact(4)
-                    .flat_map(|chunk| [chunk[0], chunk[1], chunk[2]])
-                    .collect()
-            }
-            PixelFormat::BGRA | PixelFormat::BGRX => {
-                // Swap R/B and strip alpha: BGRA -> RGB
-                self.data
-                    .chunks_exact(4)
-                    .flat_map(|chunk| [chunk[2], chunk[1], chunk[0]])
-                    .collect()
-            }
-            _ => unreachable!("Format already validated above"),
-        };
+        let image = ImagePixelSource::new(self.layout, &self.data)?;
+        let (rgb_data, width, height) = image.jpeg_rgb_input(quality)?;
 
         // Encode to JPEG
         let mut jpeg_data = Vec::new();
         let encoder = JpegEncoder::new(&mut jpeg_data, quality);
         encoder
-            .encode(
-                &rgb_data,
-                self.width() as u16,
-                self.height() as u16,
-                JpegColorType::Rgb,
-            )
+            .encode(&rgb_data, width, height, JpegColorType::Rgb)
             .map_err(|e| Error::InvalidFrame(format!("JPEG encoding failed: {e}")))?;
 
         Ok(jpeg_data)
@@ -1775,6 +1685,276 @@ pub enum ImageFormat {
     Png,
     /// JPEG format with quality setting (1-100, where 100 is highest quality)
     Jpeg(u8),
+}
+
+#[cfg(feature = "image-encoding")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImageChannelOrder {
+    Rgba,
+    Bgra,
+}
+
+#[cfg(feature = "image-encoding")]
+impl ImageChannelOrder {
+    fn red_index(self) -> usize {
+        match self {
+            Self::Rgba => 0,
+            Self::Bgra => 2,
+        }
+    }
+
+    fn blue_index(self) -> usize {
+        match self {
+            Self::Rgba => 2,
+            Self::Bgra => 0,
+        }
+    }
+}
+
+#[cfg(feature = "image-encoding")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImageAlphaPolicy {
+    Preserve,
+    Opaque,
+}
+
+#[cfg(feature = "image-encoding")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ImagePixelFormat {
+    channel_order: ImageChannelOrder,
+    alpha_policy: ImageAlphaPolicy,
+}
+
+#[cfg(feature = "image-encoding")]
+impl ImagePixelFormat {
+    const BYTES_PER_PIXEL: usize = 4;
+
+    fn from_pixel_format(pixel_format: PixelFormat) -> Result<Self> {
+        match pixel_format {
+            PixelFormat::RGBA => Ok(Self {
+                channel_order: ImageChannelOrder::Rgba,
+                alpha_policy: ImageAlphaPolicy::Preserve,
+            }),
+            PixelFormat::BGRA => Ok(Self {
+                channel_order: ImageChannelOrder::Bgra,
+                alpha_policy: ImageAlphaPolicy::Preserve,
+            }),
+            PixelFormat::RGBX => Ok(Self {
+                channel_order: ImageChannelOrder::Rgba,
+                alpha_policy: ImageAlphaPolicy::Opaque,
+            }),
+            PixelFormat::BGRX => Ok(Self {
+                channel_order: ImageChannelOrder::Bgra,
+                alpha_policy: ImageAlphaPolicy::Opaque,
+            }),
+            _ => Err(Error::InvalidFrame(format!(
+                "Unsupported format for image encoding: {pixel_format:?}. Only RGBA/RGBX/BGRA/BGRX are supported."
+            ))),
+        }
+    }
+
+    fn can_borrow_tightly_packed_png(self) -> bool {
+        self.channel_order == ImageChannelOrder::Rgba
+            && self.alpha_policy == ImageAlphaPolicy::Preserve
+    }
+
+    fn rgba_pixel(self, pixel: &[u8]) -> [u8; 4] {
+        [
+            pixel[self.channel_order.red_index()],
+            pixel[1],
+            pixel[self.channel_order.blue_index()],
+            match self.alpha_policy {
+                ImageAlphaPolicy::Preserve => pixel[3],
+                ImageAlphaPolicy::Opaque => 255,
+            },
+        ]
+    }
+
+    fn rgb_pixel(self, pixel: &[u8]) -> [u8; 3] {
+        [
+            pixel[self.channel_order.red_index()],
+            pixel[1],
+            pixel[self.channel_order.blue_index()],
+        ]
+    }
+}
+
+#[cfg(feature = "image-encoding")]
+#[derive(Debug)]
+struct ImagePixelSource<'a> {
+    data: &'a [u8],
+    width: usize,
+    height: usize,
+    line_stride: usize,
+    active_row_bytes: usize,
+    pixel_format: ImagePixelFormat,
+}
+
+#[cfg(feature = "image-encoding")]
+impl<'a> ImagePixelSource<'a> {
+    fn new(layout: ValidatedVideoLayout, data: &'a [u8]) -> Result<Self> {
+        let pixel_format = ImagePixelFormat::from_pixel_format(layout.pixel_format)?;
+
+        if data.len() != layout.data_len_bytes {
+            return Err(Error::InvalidFrame(format!(
+                "Video data length {}, expected {} bytes for validated layout",
+                data.len(),
+                layout.data_len_bytes
+            )));
+        }
+
+        let line_stride = match layout.line_stride_or_size {
+            LineStrideOrSize::LineStrideBytes(stride) => {
+                if stride <= 0 {
+                    return Err(Error::InvalidFrame(format!(
+                        "Image line stride must be positive, got {stride}"
+                    )));
+                }
+
+                usize::try_from(stride).map_err(|_| {
+                    Error::InvalidFrame(format!("Invalid image line stride value: {stride}"))
+                })?
+            }
+            LineStrideOrSize::DataSizeBytes(size) => {
+                return Err(Error::InvalidFrame(format!(
+                    "Cannot encode image from data-size frame ({size} bytes). Image encoding requires line_stride_in_bytes."
+                )));
+            }
+        };
+
+        let width = usize::try_from(layout.width)
+            .map_err(|_| Error::InvalidFrame(format!("Invalid image width: {}", layout.width)))?;
+        let height = usize::try_from(layout.height)
+            .map_err(|_| Error::InvalidFrame(format!("Invalid image height: {}", layout.height)))?;
+
+        if width == 0 || height == 0 {
+            return Err(Error::InvalidFrame(format!(
+                "Image dimensions must be positive, got {}x{}",
+                layout.width, layout.height
+            )));
+        }
+
+        let active_row_bytes = width
+            .checked_mul(ImagePixelFormat::BYTES_PER_PIXEL)
+            .ok_or_else(|| {
+                Error::InvalidFrame(format!(
+                    "Image row size overflow for width {} and {} bytes per pixel",
+                    width,
+                    ImagePixelFormat::BYTES_PER_PIXEL
+                ))
+            })?;
+
+        if line_stride < active_row_bytes {
+            return Err(Error::InvalidFrame(format!(
+                "Image line stride {line_stride} is smaller than active row size {active_row_bytes}"
+            )));
+        }
+
+        let expected_data_len = line_stride.checked_mul(height).ok_or_else(|| {
+            Error::InvalidFrame(format!(
+                "Image data length overflow: {line_stride} stride x {height} height"
+            ))
+        })?;
+
+        if expected_data_len != layout.data_len_bytes {
+            return Err(Error::InvalidFrame(format!(
+                "Image layout data length {} does not match line stride x height ({expected_data_len})",
+                layout.data_len_bytes
+            )));
+        }
+
+        Ok(Self {
+            data,
+            width,
+            height,
+            line_stride,
+            active_row_bytes,
+            pixel_format,
+        })
+    }
+
+    fn png_rgba_input(&self) -> Result<(Cow<'a, [u8]>, u32, u32)> {
+        let width = u32::try_from(self.width).map_err(|_| {
+            Error::InvalidFrame(format!("PNG width {} exceeds u32 range", self.width))
+        })?;
+        let height = u32::try_from(self.height).map_err(|_| {
+            Error::InvalidFrame(format!("PNG height {} exceeds u32 range", self.height))
+        })?;
+
+        if self.pixel_format.can_borrow_tightly_packed_png()
+            && self.line_stride == self.active_row_bytes
+        {
+            return Ok((Cow::Borrowed(self.data), width, height));
+        }
+
+        let mut rgba = Vec::with_capacity(self.output_len(4)?);
+
+        if self.pixel_format.can_borrow_tightly_packed_png() {
+            for row in self.active_rows() {
+                rgba.extend_from_slice(row);
+            }
+        } else {
+            for row in self.active_rows() {
+                for pixel in row.chunks_exact(ImagePixelFormat::BYTES_PER_PIXEL) {
+                    rgba.extend_from_slice(&self.pixel_format.rgba_pixel(pixel));
+                }
+            }
+        }
+
+        Ok((Cow::Owned(rgba), width, height))
+    }
+
+    fn jpeg_rgb_input(&self, quality: u8) -> Result<(Vec<u8>, u16, u16)> {
+        if !(1..=100).contains(&quality) {
+            return Err(Error::InvalidFrame(format!(
+                "JPEG quality must be in 1..=100, got {quality}"
+            )));
+        }
+
+        let width = u16::try_from(self.width).map_err(|_| {
+            Error::InvalidFrame(format!(
+                "JPEG width {} exceeds maximum supported value {}",
+                self.width,
+                u16::MAX
+            ))
+        })?;
+        let height = u16::try_from(self.height).map_err(|_| {
+            Error::InvalidFrame(format!(
+                "JPEG height {} exceeds maximum supported value {}",
+                self.height,
+                u16::MAX
+            ))
+        })?;
+
+        let mut rgb = Vec::with_capacity(self.output_len(3)?);
+        for row in self.active_rows() {
+            for pixel in row.chunks_exact(ImagePixelFormat::BYTES_PER_PIXEL) {
+                rgb.extend_from_slice(&self.pixel_format.rgb_pixel(pixel));
+            }
+        }
+
+        Ok((rgb, width, height))
+    }
+
+    fn output_len(&self, channels: usize) -> Result<usize> {
+        self.width
+            .checked_mul(self.height)
+            .and_then(|pixels| pixels.checked_mul(channels))
+            .ok_or_else(|| {
+                Error::InvalidFrame(format!(
+                    "Image output buffer size overflow: {}x{}x{}",
+                    self.width, self.height, channels
+                ))
+            })
+    }
+
+    fn active_rows(&self) -> impl Iterator<Item = &'a [u8]> + '_ {
+        (0..self.height).map(move |row| {
+            let start = row * self.line_stride;
+            let end = start + self.active_row_bytes;
+            &self.data[start..end]
+        })
+    }
 }
 
 // ============================================================================
@@ -2896,6 +3076,238 @@ impl<'rx> fmt::Debug for MetadataFrameRef<'rx> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "image-encoding")]
+    fn image_test_frame(
+        pixel_format: PixelFormat,
+        width: i32,
+        height: i32,
+        line_stride: Option<i32>,
+        data: Vec<u8>,
+    ) -> VideoFrame {
+        let layout =
+            ValidatedVideoLayout::new_uncompressed(pixel_format, width, height, line_stride)
+                .unwrap();
+        assert_eq!(data.len(), layout.data_len_bytes);
+
+        VideoFrame {
+            layout,
+            frame_rate_n: 60,
+            frame_rate_d: 1,
+            picture_aspect_ratio: 16.0 / 9.0,
+            scan_type: ScanType::Progressive,
+            timecode: 0,
+            data,
+            metadata: None,
+            timestamp: 0,
+        }
+    }
+
+    #[cfg(feature = "image-encoding")]
+    fn decode_png_rgba(png_bytes: &[u8]) -> (u32, u32, Vec<u8>) {
+        let decoder = png::Decoder::new(std::io::Cursor::new(png_bytes));
+        let mut reader = decoder.read_info().unwrap();
+        let output_size = reader.output_buffer_size().unwrap();
+        let mut output = vec![0; output_size];
+        let info = reader.next_frame(&mut output).unwrap();
+        output.truncate(info.buffer_size());
+
+        assert_eq!(info.color_type, png::ColorType::Rgba);
+        assert_eq!(info.bit_depth, png::BitDepth::Eight);
+
+        (info.width, info.height, output)
+    }
+
+    #[cfg(feature = "image-encoding")]
+    fn assert_jpeg_markers(jpeg_bytes: &[u8]) {
+        assert!(jpeg_bytes.len() >= 4);
+        assert_eq!(&jpeg_bytes[..2], &[0xFF, 0xD8]);
+        assert_eq!(&jpeg_bytes[jpeg_bytes.len() - 2..], &[0xFF, 0xD9]);
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_png_decodes_exact_supported_pixels() {
+        let cases = [
+            (
+                PixelFormat::RGBA,
+                vec![10, 20, 30, 40, 50, 60, 70, 80],
+                vec![10, 20, 30, 40, 50, 60, 70, 80],
+            ),
+            (
+                PixelFormat::BGRA,
+                vec![30, 20, 10, 40, 70, 60, 50, 80],
+                vec![10, 20, 30, 40, 50, 60, 70, 80],
+            ),
+            (
+                PixelFormat::RGBX,
+                vec![10, 20, 30, 0, 50, 60, 70, 99],
+                vec![10, 20, 30, 255, 50, 60, 70, 255],
+            ),
+            (
+                PixelFormat::BGRX,
+                vec![30, 20, 10, 0, 70, 60, 50, 99],
+                vec![10, 20, 30, 255, 50, 60, 70, 255],
+            ),
+        ];
+
+        for (pixel_format, data, expected) in cases {
+            let frame = image_test_frame(pixel_format, 2, 1, None, data);
+            let png = frame.encode_png().unwrap();
+            let (width, height, decoded) = decode_png_rgba(&png);
+
+            assert_eq!((width, height), (2, 1), "{pixel_format:?}");
+            assert_eq!(decoded, expected, "{pixel_format:?}");
+        }
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_png_skips_padded_rows() {
+        let data = vec![
+            1, 2, 3, 0, 4, 5, 6, 0, 200, 201, 202, 203, 7, 8, 9, 0, 10, 11, 12, 0, 204, 205, 206,
+            207,
+        ];
+        let frame = image_test_frame(PixelFormat::RGBX, 2, 2, Some(12), data);
+
+        let png = frame.encode_png().unwrap();
+        let (width, height, decoded) = decode_png_rgba(&png);
+
+        assert_eq!((width, height), (2, 2));
+        assert_eq!(
+            decoded,
+            vec![1, 2, 3, 255, 4, 5, 6, 255, 7, 8, 9, 255, 10, 11, 12, 255,]
+        );
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_jpeg_accepts_supported_image_formats() {
+        let cases = [
+            (PixelFormat::RGBA, vec![10, 20, 30, 40]),
+            (PixelFormat::BGRA, vec![30, 20, 10, 40]),
+            (PixelFormat::RGBX, vec![10, 20, 30, 0]),
+            (PixelFormat::BGRX, vec![30, 20, 10, 0]),
+        ];
+
+        for (pixel_format, pixel) in cases {
+            let data = pixel.repeat(16);
+            let frame = image_test_frame(pixel_format, 4, 4, None, data);
+            let jpeg = frame.encode_jpeg(90).unwrap();
+            assert_jpeg_markers(&jpeg);
+        }
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_jpeg_skips_padded_rows() {
+        let data = vec![
+            3, 2, 1, 0, 6, 5, 4, 0, 250, 251, 252, 253, 9, 8, 7, 0, 12, 11, 10, 0, 254, 255, 0, 1,
+        ];
+        let frame = image_test_frame(PixelFormat::BGRX, 2, 2, Some(12), data);
+
+        let jpeg = frame.encode_jpeg(85).unwrap();
+        assert_jpeg_markers(&jpeg);
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_jpeg_rejects_invalid_quality() {
+        let frame = image_test_frame(PixelFormat::RGBA, 2, 2, None, vec![0; 16]);
+
+        for quality in [0, 101, 255] {
+            let err = frame.encode_jpeg(quality).unwrap_err();
+            let err_msg = err.to_string();
+            assert!(
+                matches!(&err, Error::InvalidFrame(message) if message.contains("quality")),
+                "unexpected error for quality {quality}: {err_msg}"
+            );
+        }
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_jpeg_rejects_oversized_dimensions_before_casting() {
+        let wide = image_test_frame(PixelFormat::RGBA, 65_536, 1, None, vec![0; 65_536 * 4]);
+        let err = wide.encode_jpeg(85).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            matches!(&err, Error::InvalidFrame(message) if message.contains("JPEG width")),
+            "unexpected error: {err_msg}"
+        );
+
+        let tall = image_test_frame(PixelFormat::RGBA, 1, 65_536, None, vec![0; 65_536 * 4]);
+        let err = tall.encode_jpeg(85).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            matches!(&err, Error::InvalidFrame(message) if message.contains("JPEG height")),
+            "unexpected error: {err_msg}"
+        );
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_encode_jpeg_rejects_unsupported_format() {
+        let frame = image_test_frame(PixelFormat::UYVY, 2, 2, None, vec![0; 8]);
+
+        let err = frame.encode_jpeg(85).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            matches!(&err, Error::InvalidFrame(message) if message.contains("Unsupported format")),
+            "unexpected error: {err_msg}"
+        );
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_png_input_borrows_only_tightly_packed_rgba() {
+        let rgba = image_test_frame(PixelFormat::RGBA, 2, 1, None, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        let source = ImagePixelSource::new(rgba.layout, rgba.data()).unwrap();
+        let (pixels, _, _) = source.png_rgba_input().unwrap();
+        assert!(matches!(pixels, Cow::Borrowed(_)));
+
+        let padded_rgba = image_test_frame(
+            PixelFormat::RGBA,
+            2,
+            1,
+            Some(12),
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 200, 201, 202, 203],
+        );
+        let source = ImagePixelSource::new(padded_rgba.layout, padded_rgba.data()).unwrap();
+        let (pixels, _, _) = source.png_rgba_input().unwrap();
+        assert!(matches!(pixels, Cow::Owned(_)));
+
+        let rgbx = image_test_frame(PixelFormat::RGBX, 2, 1, None, vec![1, 2, 3, 0, 5, 6, 7, 0]);
+        let source = ImagePixelSource::new(rgbx.layout, rgbx.data()).unwrap();
+        let (pixels, _, _) = source.png_rgba_input().unwrap();
+        assert!(matches!(pixels, Cow::Owned(_)));
+    }
+
+    #[cfg(feature = "image-encoding")]
+    #[test]
+    fn test_image_pixel_source_rejects_data_size_layout_and_bad_data_len() {
+        let data_size_layout = ValidatedVideoLayout {
+            width: 2,
+            height: 1,
+            pixel_format: PixelFormat::RGBA,
+            data_len_bytes: 8,
+            line_stride_or_size: LineStrideOrSize::DataSizeBytes(8),
+        };
+        let err = ImagePixelSource::new(data_size_layout, &[0; 8]).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            matches!(&err, Error::InvalidFrame(message) if message.contains("data-size frame")),
+            "unexpected error: {err_msg}"
+        );
+
+        let layout = ValidatedVideoLayout::new_uncompressed(PixelFormat::RGBA, 2, 1, None).unwrap();
+        let err = ImagePixelSource::new(layout, &[0; 7]).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            matches!(&err, Error::InvalidFrame(message) if message.contains("Video data length")),
+            "unexpected error: {err_msg}"
+        );
+    }
 
     /// Test PixelFormatInfo for packed RGB formats (32 bpp)
     #[test]


### PR DESCRIPTION
Closes #62

## Summary
- Centralize PNG/JPEG image pixel conversion behind one private row-stride-aware helper.
- Treat RGBX/BGRX X bytes as padding for PNG alpha and skip valid row padding for PNG/JPEG.
- Validate JPEG quality and dimensions before encoding.
- Enable image encoding by default while preserving a minimal opt-out with default-features = false.
- Remove the unused lodepng build dependency and update the PNG example/docs.

## Verification
- cargo fmt --check
- cargo test
- cargo test --features image-encoding
- cargo test --no-default-features
- cargo test --all-features
- cargo test --lib
- cargo test --doc
- cargo check --example NDIlib_Recv_PNG